### PR TITLE
[android-security-13.0.0_r9] Fix permission issue in legacy shortcut

### DIFF
--- a/src/com/android/launcher3/util/PackageManagerHelper.java
+++ b/src/com/android/launcher3/util/PackageManagerHelper.java
@@ -145,6 +145,18 @@ public class PackageManagerHelper {
      * any permissions
      */
     public boolean hasPermissionForActivity(Intent intent, String srcPackage) {
+        // b/270152142
+        if (Intent.ACTION_CHOOSER.equals(intent.getAction())) {
+            final Bundle extras = intent.getExtras();
+            if (extras == null) {
+                return true;
+            }
+            // If given intent is ACTION_CHOOSER, verify srcPackage has permission over EXTRA_INTENT
+            intent = (Intent) extras.getParcelable(Intent.EXTRA_INTENT);
+            if (intent == null) {
+                return true;
+            }
+        }
         ResolveInfo target = mPm.resolveActivity(intent, 0);
         if (target == null) {
             // Not a valid target


### PR DESCRIPTION
When building legacy shortcut, Launcher calls
PackageManager#resolveActivity to retrieve necessary permission to launch the intent.

However, when the source app wraps an arbitrary intent within Intent#createChooser, the existing logic will fail because launching Chooser doesn't require additional permission.

This CL fixes the security vulnerability by performing the permission check against the intent that is wrapped within.

Bug: 270152142
Test: manual
(cherry picked from https://googleplex-android-review.googlesource.com/q/commit:c53818a16b4322a823497726ac7e7a44501b4442) Merged-In: If35344c08975e35085c7c2b9b814a3c457a144b0 Change-Id: If35344c08975e35085c7c2b9b814a3c457a144b0