### PR TITLE
lower targetSdk to 33

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -207,7 +207,7 @@ android_app {
 
     sdk_version: "current",
     min_sdk_version: min_launcher3_sdk_version,
-    target_sdk_version: "current",
+    target_sdk_version: "33",
     privileged: true,
     system_ext_specific: true,
 
@@ -335,7 +335,7 @@ android_app {
 
     sdk_version: "current",
     min_sdk_version: "current",
-    target_sdk_version: "current",
+    target_sdk_version: "33",
     privileged: true,
     system_ext_specific: true,
     overrides: [
@@ -369,7 +369,7 @@ android_app {
 
     platform_apis: true,
     min_sdk_version: "current",
-    target_sdk_version: "current",
+    target_sdk_version: "33",
 
     privileged: true,
     system_ext_specific: true,
@@ -406,7 +406,7 @@ android_app {
 
     platform_apis: true,
     min_sdk_version: "current",
-    target_sdk_version: "current",
+    target_sdk_version: "33",
 
     srcs: [ ],
 


### PR DESCRIPTION
It seems that it's been raised accidentally, stock OS launcher (which is based on this repo) still targets SDK 33, and targetSdk 33 is set in AndroidManifest.

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/2485