### PR TITLE
remove "Install in private" shortcut

### DIFF
--- a/quickstep/src/com/android/launcher3/uioverrides/QuickstepLauncher.java
+++ b/quickstep/src/com/android/launcher3/uioverrides/QuickstepLauncher.java
@@ -454,9 +454,6 @@ public class QuickstepLauncher extends Launcher implements RecentsViewContainer 
         shortcuts.add(STORAGE_SCOPES);
         shortcuts.add(CONTACT_SCOPES);
         shortcuts.add(INSTALL);
-        if (Flags.enablePrivateSpaceInstallShortcut()) {
-            shortcuts.add(PRIVATE_PROFILE_INSTALL);
-        }
         if (Flags.enableShortcutDontSuggestApp()) {
             shortcuts.add(DONT_SUGGEST_APP);
         }


### PR DESCRIPTION
It opens the first party app source, which is not useful currently on GrapheneOS.