### PR TITLE
Launcher3: fix app drawer in 2x2 grid size

### DIFF
--- a/res/xml/device_profiles.xml
+++ b/res/xml/device_profiles.xml
@@ -34,6 +34,8 @@
             launcher:minHeightDps="200"
             launcher:iconImageSize="48"
             launcher:iconTextSize="12.0"
+            launcher:allAppsBorderSpace="16"
+            launcher:allAppsCellHeight="104"
             launcher:canBeDefault="true" />
 
         <display-option
@@ -42,6 +44,8 @@
             launcher:minHeightDps="300"
             launcher:iconImageSize="48"
             launcher:iconTextSize="12.0"
+            launcher:allAppsBorderSpace="16"
+            launcher:allAppsCellHeight="104"
             launcher:canBeDefault="true" />
 
     </grid-option>


### PR DESCRIPTION
fixes https://github.com/GrapheneOS/os-issue-tracker/issues/2320

screenshot of the app drawer with this pr is below
![Screenshot_20250201-203321](https://github.com/user-attachments/assets/e022852f-a760-4d6b-a9d1-8a995afce7fb)
