### PR TITLE
add a workaround for QuickstepModelDelegate.getContainer() crash

### DIFF
--- a/quickstep/src/com/android/launcher3/model/QuickstepModelDelegate.java
+++ b/quickstep/src/com/android/launcher3/model/QuickstepModelDelegate.java
@@ -247,8 +247,8 @@ public class QuickstepModelDelegate extends ModelDelegate {
                         "Item info: %s found with invalid container: %s",
                         info,
                         containerInfo));
+                return null;
             }
-            // Allow crash to help debug b/173838775
             return (CollectionInfo) containerInfo;
         }
         return null;


### PR DESCRIPTION
See https://github.com/GrapheneOS/os-issue-tracker/issues/6578

It's not clear how to reproduce the crash, but the method that crashes is used only for logging and its callers check for the null return value.

See 380f8fd89016b2527d9a3fb2b35c0c4810e12855 for more info.