### PR TITLE
fix crash from AllAppsActionManager race condition from user switch

### DIFF
--- a/quickstep/src/com/android/quickstep/AllAppsActionManager.kt
+++ b/quickstep/src/com/android/quickstep/AllAppsActionManager.kt
@@ -23,6 +23,7 @@ import android.content.Context
 import android.graphics.drawable.Icon
 import android.provider.Settings
 import android.provider.Settings.Secure.USER_SETUP_COMPLETE
+import android.util.Log
 import android.view.accessibility.AccessibilityManager
 import com.android.launcher3.R
 import com.android.launcher3.util.SettingsCache
@@ -48,6 +49,8 @@ class AllAppsActionManager(
 ) {
 
     private val onSettingsChangeListener = OnChangeListener { v -> isUserSetupComplete = v }
+
+    private var isDestroyed = false
 
     init {
         SettingsCache.INSTANCE[context].register(USER_SETUP_COMPLETE_URI, onSettingsChangeListener)
@@ -94,6 +97,11 @@ class AllAppsActionManager(
 
     private fun updateSystemAction() {
         synchronized(this) {
+            if (isDestroyed) {
+                Log.w(TAG, "updateSystemAction called when destroyed", Throwable())
+                return
+            }
+
             val isInSetupFlow = isSetupUiVisible || !isUserSetupComplete
             val shouldRegisterAction =
                 (isHomeAndOverviewSame || isTaskbarPresent) && !isInSetupFlow && isUserUnlocked
@@ -101,27 +109,36 @@ class AllAppsActionManager(
             isActionRegistered = shouldRegisterAction
 
             bgExecutor.execute {
-                val accessibilityManager =
-                    context.getSystemService(AccessibilityManager::class.java) ?: return@execute
-                if (shouldRegisterAction) {
-                    val allAppsPendingIntent = createAllAppsPendingIntent()
-                    accessibilityManager.registerSystemAction(
-                        RemoteAction(
-                            Icon.createWithResource(context, R.drawable.ic_apps),
-                            context.getString(R.string.all_apps_label),
-                            context.getString(R.string.all_apps_label),
-                            allAppsPendingIntent,
-                        ),
-                        GLOBAL_ACTION_ACCESSIBILITY_ALL_APPS,
-                    )
-                    quickstepKeyGestureEventsManager.registerAllAppsKeyGestureEvent(
-                        allAppsPendingIntent
-                    )
-                } else {
-                    accessibilityManager.unregisterSystemAction(
-                        GLOBAL_ACTION_ACCESSIBILITY_ALL_APPS
-                    )
-                    quickstepKeyGestureEventsManager.unregisterAllAppsKeyGestureEvent()
+                synchronized(this@AllAppsActionManager) {
+                    if (isDestroyed) {
+                        isActionRegistered = false
+                        Log.w(TAG, "updateSystemAction bgExecutor task running " +
+                                "when destroyed; shouldRegisterAction $shouldRegisterAction")
+                        return@execute
+                    }
+
+                    val accessibilityManager =
+                        context.getSystemService(AccessibilityManager::class.java) ?: return@execute
+                    if (shouldRegisterAction) {
+                        val allAppsPendingIntent = createAllAppsPendingIntent()
+                        accessibilityManager.registerSystemAction(
+                            RemoteAction(
+                                Icon.createWithResource(context, R.drawable.ic_apps),
+                                context.getString(R.string.all_apps_label),
+                                context.getString(R.string.all_apps_label),
+                                allAppsPendingIntent,
+                            ),
+                            GLOBAL_ACTION_ACCESSIBILITY_ALL_APPS,
+                        )
+                        quickstepKeyGestureEventsManager.registerAllAppsKeyGestureEvent(
+                            allAppsPendingIntent
+                        )
+                    } else {
+                        accessibilityManager.unregisterSystemAction(
+                            GLOBAL_ACTION_ACCESSIBILITY_ALL_APPS
+                        )
+                        quickstepKeyGestureEventsManager.unregisterAllAppsKeyGestureEvent()
+                    }
                 }
             }
         }
@@ -129,6 +146,7 @@ class AllAppsActionManager(
 
     fun onDestroy() {
         synchronized(this) {
+            isDestroyed = true
             isActionRegistered = false
             context
                 .getSystemService(AccessibilityManager::class.java)
@@ -149,5 +167,9 @@ class AllAppsActionManager(
         pw.println("\tisUserSetupComplete=$isUserSetupComplete")
         pw.println("\tisActionRegistered=$isActionRegistered")
         pw.println("\tisUserUnlocked=$isUserUnlocked")
+    }
+
+    companion object {
+        private const val TAG = "AllAppsActionManager"
     }
 }


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/7142

When switching users, `TouchInteractionService#onDestroy` is called in the Launcher of the user
that's leaving. This method calls `mOverviewComponentObserver.setHomeDisabled(false)` which calls
`AllAppsActionManager#updateSystemAction`. This posts a task to the background executor 
(`bgExecutor`) which may result in calling 
`QuickstepKeyGestureEventsManager#registerAllAppsKeyGestureEvent`.

Stacktrace for `mOverviewComponentObserver.setHomeDisabled(false)` call:

```
com.android.quickstep.AllAppsActionManager.updateSystemAction(AllAppsActionManager.kt:109)
at com.android.quickstep.AllAppsActionManager.setHomeAndOverviewSame(AllAppsActionManager.kt:60)
at com.android.quickstep.TouchInteractionService.onOverviewTargetChanged(TouchInteractionService.java:948)
at com.android.quickstep.TouchInteractionService.$r8$lambda$bRfCFYdJhx0jEe_-C1evD6SJA4Q(TouchInteractionService.java:0)
at com.android.quickstep.TouchInteractionService$$ExternalSyntheticLambda10.onOverviewTargetChange(R8$$SyntheticClass:0)
at com.android.quickstep.OverviewComponentObserver.lambda$updateOverviewTargets$0(OverviewComponentObserver.java:272)
at com.android.quickstep.OverviewComponentObserver.$r8$lambda$WwXEFfm8DBVLG1Aw8sJ7SAlcWOs(OverviewComponentObserver.java:0)
at com.android.quickstep.OverviewComponentObserver$$ExternalSyntheticLambda1.accept(R8$$SyntheticClass:0)
at java.util.concurrent.CopyOnWriteArrayList.forEach(CopyOnWriteArrayList.java:895)
at com.android.quickstep.OverviewComponentObserver.updateOverviewTargets(OverviewComponentObserver.java:272)
at com.android.quickstep.OverviewComponentObserver.setHomeDisabled(OverviewComponentObserver.java:182)
at com.android.quickstep.TouchInteractionService.onDestroy(TouchInteractionService.java:1012)
```

However, `TouchInteractionService#onDestroy` also calls `AllAppsActionManager#onDestroy` later on
which calls `QuickstepKeyGestureEventsManager#unregisterAllAppsKeyGestureEvent` from the main
thread. 

This yields a race condition: 

- `unregisterAllAppsKeyGestureEvent` can be first from `AllAppsActionManager#onDestroy`.
- Then, the task posted to the `bgExecutor` from `mOverviewComponentObserver.setHomeDisabled(false)`
  executes and calls `registerAllAppsKeyGestureEvent`.

The result is that the Launcher of the previous user will still have
`KeyGestureEvent.KEY_GESTURE_TYPE_ALL_APPS` (21) registered with the `InputManager` service; this
will prevent the new user's Launcher from registering it resulting in the new user's Launcher crash.
This will continue and the new user will be unable to use the Launcher for a while.

The fix is to add some indication that `AllAppsActionManager` has been destroyed and have the
background task read it in a synchronized block. `AllAppsActionManager` isn't a singleton, and from
its design (e.g., the `init` block is the only place where the settings observer is registered, and
destroy function removes that observer), it's meant to be garbage collected after
`TouchInteractionService` is destroyed. Instances of `AllAppsActionManager` are not created anywhere
else other than `TouchInteractionService` and test code.

As a remark, this does not appear to be the first time this Android 16 code has been subject to race
conditions:
https://cs.android.com/android/_/android/platform/packages/apps/Launcher3/+/ea2bd05977db89cafa6a0762c10c06f3fa20dc89

Flag: com.android.window.flags.grant_manage_key_gestures_to_recents
Test: Quickstep doesn't have unit tests in AOSP; there are unit test files but not defined in any 
Soong module. Commit messages mention NexusLauncherTests; that's for Pixel Launcher.
Test: Manual: By switching users (with 3-button gesture enabled) constantly, eventually the log line
`W AllAppsActionManager: updateSystemAction bgExecutor task running when destroyed; shouldRegisterAction true`
appears, indicating that the background task was stopped successfully.