### PR TITLE
Keep keyboard open when search text is fully deleted in app drawer

### DIFF
--- a/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
+++ b/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
@@ -71,6 +71,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.android.launcher3.DeviceProfile;
 import com.android.launcher3.DeviceProfile.OnDeviceProfileChangeListener;
 import com.android.launcher3.DragSource;
+import com.android.launcher3.ExtendedEditText;
 import com.android.launcher3.DropTarget.DragObject;
 import com.android.launcher3.Flags;
 import com.android.launcher3.Insettable;
@@ -570,7 +571,14 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
             return;
         }
         if (currentActivePage != SEARCH) {
-            mActivityContext.hideKeyboard();
+            // Only hide the keyboard if the search field is no longer focused.
+            // When the user deletes all text, onClearSearchResult() exits search
+            // mode which triggers this callback. Without this guard the keyboard
+            // closes, forcing the user to tap the search box again to retype.
+            ExtendedEditText editText = mSearchUiManager.getEditText();
+            if (editText == null || !editText.isFocused()) {
+                mActivityContext.hideKeyboard();
+            }
         }
         if (mAH.get(currentActivePage).mRecyclerView != null) {
             mAH.get(currentActivePage).mRecyclerView.bindFastScrollbar(mFastScroller,


### PR DESCRIPTION
## Summary
- When the user deletes all text in the app drawer search field, the keyboard currently closes because `onClearSearchResult()` unconditionally exits search mode
- This adds an `isFocused()` guard so the keyboard stays open while the search field is still focused
- The existing back-key handler already handles explicit exit with keyboard dismissal

## Problem
In the app drawer, typing to search for an app and then deleting all characters causes the keyboard to close. To search again, the user must tap the search box again. The expected behavior is that the keyboard stays open after deleting all text, and only closes when the user explicitly presses back.

## Root cause
`onClearSearchResult()` calls `animateToSearchState(false)` unconditionally. This exits search mode, which triggers `onActivePageChanged()`, which calls `hideKeyboard()`. Empty query is treated as "exit search" rather than "ready to retype."

## Fix
Guard `animateToSearchState(false)` in `onClearSearchResult()` with `editText.isFocused()`. If the search field is still focused (user is actively using it), the search results clear and the app list returns to the full A-Z view, but the keyboard stays up.

## Prior art
The same bug existed in Lawnchair (also a Launcher3 fork) and was fixed: [lawnchair#4095](https://github.com/LawnchairLauncher/lawnchair/issues/4095) via [commit 43a5cc7](https://github.com/LawnchairLauncher/lawnchair/commit/43a5cc7).

Fixes: https://github.com/GrapheneOS/os-issue-tracker/issues/3970