### PR TITLE
AppsScope: Integrate Apps Scope shortcut

### DIFF
--- a/quickstep/src/com/android/launcher3/uioverrides/QuickstepLauncher.java
+++ b/quickstep/src/com/android/launcher3/uioverrides/QuickstepLauncher.java
@@ -55,6 +55,7 @@ import static com.android.launcher3.model.data.ItemInfoWithIcon.FLAG_NOT_PINNABL
 import static com.android.launcher3.popup.QuickstepSystemShortcut.getSplitSelectShortcutByPosition;
 import static com.android.launcher3.popup.SystemShortcut.ADD_TO_HOME_SCREEN;
 import static com.android.launcher3.popup.SystemShortcut.APP_INFO;
+import static com.android.launcher3.popup.SystemShortcut.APPS_SCOPES;
 import static com.android.launcher3.popup.SystemShortcut.BUBBLE_SHORTCUT;
 import static com.android.launcher3.popup.SystemShortcut.CONTACT_SCOPES;
 import static com.android.launcher3.popup.SystemShortcut.DONT_SUGGEST_APP;
@@ -551,6 +552,7 @@ public class QuickstepLauncher extends Launcher implements RecentsViewContainer,
         shortcuts.add(WIDGETS);
         shortcuts.add(STORAGE_SCOPES);
         shortcuts.add(CONTACT_SCOPES);
+        shortcuts.add(APPS_SCOPES);
         shortcuts.add(INSTALL);
         // TODO(b/444744861): Update private space apps to have its own container.
         boolean isPinnable = itemInfo instanceof ItemInfoWithIcon info

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -235,6 +235,8 @@
     <string name="storage_scopes_drop_target_label">Storage Scopes</string>
     <!-- Label for Storage Scopes drop target. [CHAR_LIMIT=20] -->
     <string name="contact_scopes_label">Contact Scopes</string>
+    <!-- Label for Apps Scope drop target. [CHAR_LIMIT=20] -->
+    <string name="apps_scopes_label">Apps Scope</string>
     <!-- Label for install drop target. [CHAR_LIMIT=20] -->
     <string name="install_drop_target_label">Install</string>
     <!-- Label for dismiss prediction. -->

--- a/src/com/android/launcher3/Launcher.java
+++ b/src/com/android/launcher3/Launcher.java
@@ -2960,6 +2960,7 @@ public class Launcher extends StatefulActivity<LauncherState>
         return Stream.of(APP_INFO, WIDGETS, INSTALL
                 , com.android.launcher3.popup.SystemShortcut.STORAGE_SCOPES
                 , com.android.launcher3.popup.SystemShortcut.CONTACT_SCOPES
+                , com.android.launcher3.popup.SystemShortcut.APPS_SCOPES
         );
     }
 

--- a/src/com/android/launcher3/popup/SystemShortcut.java
+++ b/src/com/android/launcher3/popup/SystemShortcut.java
@@ -340,6 +340,30 @@ public abstract class SystemShortcut<T extends ActivityContext> extends ItemInfo
         }
     }
 
+    public static final Factory<BaseActivity> APPS_SCOPES = AppsScopes::maybeGet;
+
+    public static class AppsScopes<T extends ActivityContext> extends ScopesShortcut<T> {
+
+        private AppsScopes(T target, ItemInfo itemInfo, View originalView) {
+            super(R.drawable.ic_info_no_shadow, R.string.apps_scopes_label, target,
+                    itemInfo, originalView);
+        }
+
+        @Nullable
+        public static <T extends ActivityContext> AppsScopes<T> maybeGet(T target, ItemInfo itemInfo, View originalView) {
+            if (hasGosPackageStateFlag(itemInfo, GosPackageStateFlag.APPS_SCOPES_ENABLED)) {
+                return new AppsScopes<>(target, itemInfo, originalView);
+            }
+
+            return null;
+        }
+
+        @Override
+        protected Intent getIntent(String targetPkg) {
+            return android.app.AppsScope.createConfigActivityIntent(targetPkg);
+        }
+    }
+
     public static final Factory<ActivityContext> REMOVE = RemoveApp::new;
 
     public static class RemoveApp<T extends ActivityContext> extends SystemShortcut<T> {


### PR DESCRIPTION
At the moment, the implementation impact the following files:
/system/framework/framework.jar
/system/framework/services.jar
/system_ext/priv-app/Settings/Settings.apk
/system_ext/priv-app/Launcher3QuickStep/Launcher3QuickStep.apk

It is a 3 repository PR:
https://github.com/GrapheneOS/platform_frameworks_base
https://github.com/GrapheneOS/platform_packages_apps_Launcher3
https://github.com/GrapheneOS/platform_packages_apps_Settings

Main points of what it is implemented for now:
Individual configuration to each application to enable/disable apps scopes.
A browser of all apps that the targeted app is able to see naturally, including system apps.
Any application can be hided to one particular target, using 2 methods:
*Blacklist: hide specific applications, while the default rule is not hide.
*Whitelist: hide everything unless you specifically allow an app to be seen.
The method of whitelist/blacklist can be setup individually for user apps, and system apps.
A quick option to wipe out the apps scopes configuration of the app
A quick option to restrict everything on the app.
It is integrated in the launcher so when you hold onto an app with the apps scopes enabled, you can see a shortcut to the apps scopes configuration of that app.
