### PR TITLE
allapps: end search session on back invoked instead of an empty query

### DIFF
--- a/quickstep/dagger/com/android/launcher3/dagger/AppActivityContextModule.kt
+++ b/quickstep/dagger/com/android/launcher3/dagger/AppActivityContextModule.kt
@@ -16,10 +16,18 @@
 
 package com.android.launcher3.dagger
 
+import com.android.launcher3.taskbar.allapps.TaskbarSearchSessionController
+import com.android.launcher3.taskbar.allapps.TaskbarSearchSessionControllerImpl
+import dagger.Binds
 import dagger.Module
 
 /**
  * Module containing the app specific [ActivityContext] bindings for the final derivate app, an
  * implementation of this module should be included in the final app code.
  */
-@Module abstract class AppActivityContextModule {}
+@Module abstract class AppActivityContextModule {
+    @Binds
+    abstract fun bindTaskbarSearchSessionController(
+        impl: TaskbarSearchSessionControllerImpl
+    ): TaskbarSearchSessionController
+}

--- a/quickstep/src/com/android/launcher3/taskbar/allapps/TaskbarSearchSessionControllerImpl.kt
+++ b/quickstep/src/com/android/launcher3/taskbar/allapps/TaskbarSearchSessionControllerImpl.kt
@@ -1,0 +1,19 @@
+package com.android.launcher3.taskbar.allapps
+
+import com.android.launcher3.allapps.search.SearchSessionManager
+import com.android.launcher3.dagger.ActivityContextSingleton
+import com.android.launcher3.views.ActivityContext
+import javax.inject.Inject
+
+@ActivityContextSingleton
+class TaskbarSearchSessionControllerImpl @Inject constructor(
+    val mActivityContext: ActivityContext
+) : TaskbarSearchSessionController() {
+    override fun canHandleBackInvoked(): Boolean {
+        return SearchSessionManager.handleAllAppsSearchBackInvoked(mActivityContext, false)
+    }
+
+    override fun handleBackInvoked(): Boolean {
+        return SearchSessionManager.handleAllAppsSearchBackInvoked(mActivityContext, true)
+    }
+}

--- a/quickstep/src/com/android/launcher3/uioverrides/QuickstepLauncher.java
+++ b/quickstep/src/com/android/launcher3/uioverrides/QuickstepLauncher.java
@@ -135,6 +135,7 @@ import com.android.launcher3.Utilities;
 import com.android.launcher3.Workspace;
 import com.android.launcher3.accessibility.LauncherAccessibilityDelegate;
 import com.android.launcher3.allapps.AllAppsRecyclerView;
+import com.android.launcher3.allapps.search.SearchSessionManager;
 import com.android.launcher3.anim.AnimatorPlaybackController;
 import com.android.launcher3.anim.PendingAnimation;
 import com.android.launcher3.apppairs.AppPairIcon;
@@ -376,6 +377,13 @@ public class QuickstepLauncher extends Launcher implements RecentsViewContainer,
         if (refactorTaskbarUiState()) {
             mTaskbarUiState = TaskbarUiStateMonitor.INSTANCE.get(this)
                     .getTaskbarUiState(getDisplayId());
+        }
+    }
+
+    @Override
+    protected void onStateBack() {
+        if (!SearchSessionManager.handleAllAppsSearchBackInvoked(this, true)) {
+            super.onStateBack();
         }
     }
 

--- a/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
+++ b/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
@@ -365,7 +365,7 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
     /**
      * Sets results list for search
      */
-    public void setSearchResults(ArrayList<AdapterItem> results) {
+    public void setSearchResults(List<AdapterItem> results) {
         getMainAdapterProvider().clearHighlightedItem();
         if (getSearchResultList().setSearchResults(results)) {
             getSearchRecyclerView().onSearchResultsChanged();

--- a/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
+++ b/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
@@ -80,6 +80,7 @@ import com.android.launcher3.Utilities;
 import com.android.launcher3.allapps.BaseAllAppsAdapter.AdapterItem;
 import com.android.launcher3.allapps.search.AllAppsSearchUiDelegate;
 import com.android.launcher3.allapps.search.SearchAdapterProvider;
+import com.android.launcher3.allapps.search.SearchSessionManager;
 import com.android.launcher3.config.FeatureFlags;
 import com.android.launcher3.keyboard.FocusedItemDecorator;
 import com.android.launcher3.keyboard.ViewGroupFocusHelper;
@@ -560,7 +561,8 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
      * @return {@code true} if back gesture should exit search rather than change launcher state.
       */
     public boolean shouldBackExitSearch() {
-        return isSearching();
+        return isSearching() && SearchSessionManager.handleAllAppsSearchBackInvoked(
+                mActivityContext, false);
     }
 
     @Override

--- a/src/com/android/launcher3/allapps/AlphabeticalAppsList.java
+++ b/src/com/android/launcher3/allapps/AlphabeticalAppsList.java
@@ -216,7 +216,7 @@ public class AlphabeticalAppsList implements AllAppsStore.OnUpdateListener {
     /**
      * Sets results list for search
      */
-    public boolean setSearchResults(ArrayList<AdapterItem> results) {
+    public boolean setSearchResults(List<AdapterItem> results) {
         if (Objects.equals(results, mSearchResults)) {
             return false;
         }

--- a/src/com/android/launcher3/allapps/SearchUiManager.java
+++ b/src/com/android/launcher3/allapps/SearchUiManager.java
@@ -25,6 +25,11 @@ import com.android.launcher3.ExtendedEditText;
  * Interface for controlling the Apps search UI.
  */
 public interface SearchUiManager {
+    default boolean shouldInterceptBackButton() {
+        // In NexusLauncher, this would be stored and accessed from OneSearchSessionManager.
+        // Doing it here makes it simpler, i.e. avoids us needing to manage a SessionManagerObject.
+        return false;
+    }
 
     /**
      * Initializes the search manager.

--- a/src/com/android/launcher3/allapps/search/AllAppsSearchBarController.java
+++ b/src/com/android/launcher3/allapps/search/AllAppsSearchBarController.java
@@ -134,6 +134,10 @@ public class AllAppsSearchBarController
 
     @Override
     public boolean onBackKey() {
+        // Note: This doesn't seem to be called from ExtendedEditText#onkeyPreIme, likely because
+        // predictive back is being used.
+        Log.d(TAG, "onBackKey");
+
         // Only hide the search field if there is no query
         String query = Utilities.trim(mInput.getEditableText().toString());
         if (query.isEmpty()) {

--- a/src/com/android/launcher3/allapps/search/AppsSearchContainerLayout.java
+++ b/src/com/android/launcher3/allapps/search/AppsSearchContainerLayout.java
@@ -46,6 +46,7 @@ import com.android.launcher3.search.SearchCallback;
 import com.android.launcher3.views.ActivityContext;
 
 import java.util.ArrayList;
+import java.util.Collections;
 
 /**
  * Layout to contain the All-apps search UI.
@@ -97,6 +98,14 @@ public class AppsSearchContainerLayout extends ExtendedEditText
 
             @Override
             public void afterTextChanged(Editable s) {
+            }
+        });
+
+        addOnFocusChangeListener((v, hasFocus) -> {
+            if (hasFocus && !mIsSearchSessionActive) {
+                mIsSearchSessionActive = true;
+                // non-null list to trigger animateToSearchState
+                mAppsView.setSearchResults(Collections.emptyList());
             }
         });
 

--- a/src/com/android/launcher3/allapps/search/AppsSearchContainerLayout.java
+++ b/src/com/android/launcher3/allapps/search/AppsSearchContainerLayout.java
@@ -24,8 +24,10 @@ import static com.android.launcher3.icons.IconNormalizer.ICON_VISIBLE_AREA_FACTO
 
 import android.content.Context;
 import android.graphics.Rect;
+import android.text.Editable;
 import android.text.Selection;
 import android.text.SpannableStringBuilder;
+import android.text.TextWatcher;
 import android.text.method.TextKeyListener;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
@@ -51,6 +53,8 @@ import java.util.ArrayList;
 public class AppsSearchContainerLayout extends ExtendedEditText
         implements SearchUiManager, SearchCallback<AdapterItem>,
         AllAppsStore.OnUpdateListener, Insettable {
+
+    private boolean mIsSearchSessionActive = false;
 
     private final ActivityContext mLauncher;
     private final AllAppsSearchBarController mSearchBarController;
@@ -78,6 +82,23 @@ public class AppsSearchContainerLayout extends ExtendedEditText
         mSearchQueryBuilder = new SpannableStringBuilder();
         Selection.setSelection(mSearchQueryBuilder, 0);
         setHint(prefixTextWithIcon(getContext(), R.drawable.ic_allapps_search, getHint()));
+
+        addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                if (s != null && !s.isEmpty()) {
+                    mIsSearchSessionActive = true;
+                }
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+            }
+        });
 
         mContentOverlap =
                 getResources().getDimensionPixelSize(R.dimen.all_apps_search_bar_content_overlap);
@@ -143,7 +164,15 @@ public class AppsSearchContainerLayout extends ExtendedEditText
 
     @Override
     public void resetSearch() {
+        // The doc comment for this method in SearchUiManager says this should close any active
+        // search session.
+        mIsSearchSessionActive = false;
         mSearchBarController.reset();
+    }
+
+    @Override
+    public boolean shouldInterceptBackButton() {
+        return mIsSearchSessionActive;
     }
 
     @Override
@@ -174,11 +203,29 @@ public class AppsSearchContainerLayout extends ExtendedEditText
 
     @Override
     public void clearSearchResult() {
+        // The doc comment for clearSearchResult in the SearchCallback interface says:
+        // "Called when the search results should be cleared." This is also called when the search
+        // query is empty by AllAppsSearchBarController#afterTextChanged.
+
         // Clear the search query
         mSearchQueryBuilder.clear();
         mSearchQueryBuilder.clearSpans();
         Selection.setSelection(mSearchQueryBuilder, 0);
-        mAppsView.onClearSearchResult();
+
+        // The doc comment for ActivityAllAppsContainerView#onClearSearchResult says, "Invoke when
+        // the current search session is finished," but this is being called in a method called
+        // clearSearchResult. Finishing a search session and clearing the search result should have
+        // different semantics.
+        //
+        // NexusLauncher has similar logic guarding this call in
+        // UniversalSearchInputView#clearSearchResult.
+        if (!mIsSearchSessionActive) {
+            mAppsView.onClearSearchResult();
+        } else {
+            // Must do this or else the latest non-empty search results will remain. This is
+            // normally handled as a result of calling onClearSearchResult
+            mAppsView.setSearchResults(null);
+        }
     }
 
     @Override

--- a/src/com/android/launcher3/allapps/search/SearchSessionManager.kt
+++ b/src/com/android/launcher3/allapps/search/SearchSessionManager.kt
@@ -1,0 +1,90 @@
+package com.android.launcher3.allapps.search
+
+import android.util.Log
+import android.view.WindowInsets
+import com.android.launcher3.views.ActivityContext
+import com.android.launcher3.AbstractFloatingView
+
+/**
+ * Manages search session for all apps drawer.
+ *
+ * If we need to keep track of state, turn this into a class and add to various Dagger modules.
+ * NexusLauncher does something more complicated, since they want to hold reference to the
+ * ActivityContext
+ */
+object SearchSessionManager {
+    private const val TAG = "LSearchSessionManager"
+
+    private inline fun verboseLog(makeLog: () -> String) {
+        if (Log.isLoggable(TAG, Log.VERBOSE)) {
+            Log.v(TAG, makeLog())
+        }
+    }
+
+    /**
+     * Returns true if the search session handled the back invocation. If [doActions] is false,
+     * then this method just becomes a query on whether the back invocation would be handled.
+     *
+     * [doActions] will be false on calls for things such as predictive back gesture queries.
+     */
+    @JvmStatic
+    fun handleAllAppsSearchBackInvoked(context: ActivityContext, doActions: Boolean): Boolean {
+        verboseLog { "isAllAppsBackButtonIntercepted(ctx, $doActions)" }
+
+        val appsView = context.appsView ?: return false
+        if (!appsView.isInAllApps) {
+            return false
+        }
+
+        // This branch is present in NexusLauncher, but doesn't seem to be triggered right now in
+        // AOSP Launcher3.
+        val noInterceptTopOpenView = AbstractFloatingView.getTopOpenViewWithType(
+            context,
+            AbstractFloatingView.TYPE_TOUCH_CONTROLLER_NO_INTERCEPT
+        )
+        if (noInterceptTopOpenView != null) {
+            Log.d(TAG, "topNoInterceptOpenView ${noInterceptTopOpenView::class.java.name}")
+            if (noInterceptTopOpenView.canHandleBack()) {
+                Log.d(TAG, "topNoInterceptOpenView canHandleBack")
+                if (doActions) {
+                    noInterceptTopOpenView.onBackInvoked()
+                }
+                return true;
+            }
+        }
+
+        val manager = appsView.searchUiManager
+        val editText = manager.editText ?: return false
+        val isImeVisible = editText.rootWindowInsets?.isVisible(WindowInsets.Type.ime())
+            ?: return false
+        if (!manager.shouldInterceptBackButton()) {
+            verboseLog { "manager not allowing intercepting back, isImeVisible $isImeVisible" }
+            if (isImeVisible) {
+                if (doActions) {
+                    editText.hideKeyboard()
+                }
+                // handled back invoked since we hid the keyboard
+                return true
+            }
+            return false
+        }
+
+        // appsView.requestFocus call is made here in NexusLauncher
+        if (doActions) {
+            appsView.requestFocus()
+        }
+
+        verboseLog { "handling back button, isImeVisible $isImeVisible" }
+        // condition used in NexusLauncher
+        if (editText.text.isEmpty() || !isImeVisible) {
+            if (doActions) {
+                Log.d(TAG, "ending search session from back button");
+                manager.resetSearch()
+            }
+        } else if (doActions) {
+            editText.hideKeyboard()
+        }
+
+        return true
+    }
+}

--- a/src/com/android/launcher3/util/KeyboardShortcutsDelegate.java
+++ b/src/com/android/launcher3/util/KeyboardShortcutsDelegate.java
@@ -32,6 +32,7 @@ import com.android.launcher3.LauncherState;
 import com.android.launcher3.R;
 import com.android.launcher3.Utilities;
 import com.android.launcher3.accessibility.BaseAccessibilityDelegate;
+import com.android.launcher3.allapps.search.SearchSessionManager;
 import com.android.launcher3.testing.shared.TestProtocol;
 
 import java.util.ArrayList;
@@ -118,8 +119,11 @@ public class KeyboardShortcutsDelegate {
                 topView.close(/* animate= */ true);
                 return true;
             } else if (mLauncher.getAppsView().isInAllApps()) {
-                // Close all apps if there are no open floating views.
-                mLauncher.getStateManager().goToState(NORMAL, true);
+                // Close all apps if there are no open floating views. If search is active, close
+                // that first.
+                if (!SearchSessionManager.handleAllAppsSearchBackInvoked(mLauncher, true)) {
+                    mLauncher.getStateManager().goToState(NORMAL, true);
+                }
                 return true;
             } else if (mLauncher.isInState(LauncherState.OVERVIEW)
                     || mLauncher.isInState(LauncherState.OVERVIEW_SPLIT_SELECT)) {


### PR DESCRIPTION
Previously, the all apps drawer ends the search session when the search query is empty; this also closes the keyboard, so another search can only be initiated by retapping on the search bar. Also, during a search session, the back button closes the entire all apps drawer. Both of these behaviors goes against the search UX in other places in the OS, e.g. Launcher3's Widgets search (long press on an empty space on homescreen > Widgets > Search) doesn't have either of the behaviors. The stock OS launcher (NexusLauncher) also doesn't do this for its apps drawer search, although it does show more stuff when the search query is empty.

We now make the back button end the search session instead of an empty search query. This aligns the searching UX with other locations in the OS and stock launcher. We also ensure that the back button doesn't close the entire all apps drawer; the back button will go back to the initial all apps view before searching.

Technically, anything that calls AppsSearchContainerLayout#resetSearch will also end the search session.

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/3970



https://github.com/user-attachments/assets/5e0a9ee8-3e9b-40ba-8735-24ceb7373314


https://github.com/user-attachments/assets/8df995c0-8965-49b1-8a07-16939090adfe





