### PR TITLE
allapps: make search bar look good

### DIFF
--- a/res/values/dimens.xml
+++ b/res/values/dimens.xml
@@ -111,8 +111,8 @@
     <!-- All Apps -->
     <dimen name="all_apps_starting_vertical_translate">300dp</dimen>
     <dimen name="all_apps_search_bar_field_height">48dp</dimen>
-    <!-- all_apps_search_bar_field_height / 2 -->
-    <dimen name="all_apps_search_bar_content_overlap">24dp</dimen>
+    <!-- Revert commit to restore to 24dp if a prediction service exists -->
+    <dimen name="all_apps_search_bar_content_overlap">0dp</dimen>
     <dimen name="all_apps_search_bar_bottom_padding">30dp</dimen>
     <dimen name="all_apps_empty_search_message_top_offset">40dp</dimen>
     <dimen name="all_apps_search_top_row_extra_height">4dp</dimen>

--- a/src/com/android/launcher3/allapps/search/AppsSearchContainerLayout.java
+++ b/src/com/android/launcher3/allapps/search/AppsSearchContainerLayout.java
@@ -240,7 +240,18 @@ public class AppsSearchContainerLayout extends ExtendedEditText
     @Override
     public void setInsets(Rect insets) {
         MarginLayoutParams mlp = (MarginLayoutParams) getLayoutParams();
-        mlp.topMargin = insets.top;
+        DeviceProfile dp = mLauncher.getDeviceProfile();
+        if (dp.shouldShowAllAppsOnSheet()) {
+            // Use bottom_sheet_handle_area_height instead which is what NexusLauncher's
+            // UniversalSearchInputView does. This puts it closer to the bottom sheet handle, as it
+            // makes it flush against the handle area.
+            mlp.topMargin = getResources().getDimensionPixelSize(
+                    R.dimen.bottom_sheet_handle_area_height);
+        } else {
+            // insets.top originates from SystemWindowManagerProxy.normalizeWindowInsets:
+            // max(statusBars.top, android:dimen/status_bar_height_portrait, displayCutout.top)
+            mlp.topMargin = insets.top;
+        }
         requestLayout();
     }
 


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/6566

all_apps_search_bar_content_overlap shifts the search bar down to visually overlap with floating
header content below. Without any header content, this shifts the search bar down into empty space.

The quickstep build includes PredictionRowView and AppsDividerView in
quickstep/res/layout/floating_header_content.xml, but PredictionRowView stays GONE when no
predictions are delivered. config_defaultAppPredictionService is empty in AOSP, so system_server
never starts AppPredictionManagerService. Stock Pixel builds set this config via a device overlay
to com.google.android.as/com.google.android.apps.miphone.aiai.app.AiAiPredictionService but 
GrapheneOS excludes it. This means AppPredictionManager is null, 
PredictorState.registerPredictor() returns early, so mPredictionsEnabled stays false.

FloatingHeaderView also supports adding rows via the AllAppsRow plugin system
(com.android.systemui.action.PLUGIN_ALL_APPS_ACTIONS), but the plugin requires
com.android.systemui.permission.PLUGIN which has protectionLevel="signature" with SystemUI. The
existing plugin handling also appears incomplete. Plugin connects update mFloatingRowsHeight but
does not reliably recompute the rest of the dependent header state.  Currently, no apps in AOSP
declare this plugin action, so we assume this path won't be used for now.

Set the overlap to 0dp since there is no header content to overlap with at runtime. Tablets
(sw600dp) already use 0dp. Also, remove the stale comment that referred to the old 24dp value being
half of all_apps_search_bar_field_height.

If a prediction service is added in the future, this commit should be reverted. Predictions arrive
asynchronously after the first layout pass, so a dynamic approach (checking floating row height in
onLayout) would not work without additional work. NexusLauncher avoids this by hardcoding the 24dp
overlap unconditionally.

| Before | After |
| :-: | :-: |
| <img width="60%" alt="launcherbeforenocontentpadding-c" src="https://github.com/user-attachments/assets/2ab31d85-c9cc-4c9f-81ba-96f8a7e34de1" /> | <img width="60%" alt="launcher-after-c" src="https://github.com/user-attachments/assets/3325d2fb-60e3-4da9-ac67-180be3e7eecc" /> |

Work profile

<img width="40%" alt="launcher-workprofile-privspace-c" src="https://github.com/user-attachments/assets/a6ccbade-1481-474b-a84a-5285f3e36f56" />
