### PR TITLE
backport CP1A fix for recents overview UI bugs on third-party launchers

### DIFF
--- a/quickstep/src/com/android/quickstep/RecentsActivity.java
+++ b/quickstep/src/com/android/quickstep/RecentsActivity.java
@@ -41,6 +41,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Trace;
+import android.util.Log;
 import android.view.Display;
 import android.view.RemoteAnimationAdapter;
 import android.view.RemoteAnimationTarget;
@@ -127,6 +128,9 @@ public final class RecentsActivity extends StatefulActivity<RecentsState> implem
 
     private final Runnable mAnimationStartTimeoutRunnable = this::onAnimationStartTimeout;
     private SplitSelectStateController mSplitSelectStateController;
+
+    // from CP1A RecentsActivity
+    private boolean mIsInRecentsViewVisibleState;
     @Nullable
     private DesktopRecentsTransitionController mDesktopRecentsTransitionController;
 
@@ -430,6 +434,14 @@ public final class RecentsActivity extends StatefulActivity<RecentsState> implem
             AccessibilityManagerCompat.sendStateEventToTest(getBaseContext(),
                     OVERVIEW_STATE_ORDINAL);
         }
+        // fix from CP1A RecentsActivity
+        if (mIsInRecentsViewVisibleState && !state.isRecentsViewVisible() && !isFinishing()) {
+            Log.d(TAG, "onStateSetEnd: closeAllOpenViews and moveTaskToBack to hide Recents "
+                    + "overview");
+            AbstractFloatingView.closeAllOpenViews(this, /* animate= */ false);
+            moveTaskToBack(/* nonRoot= */ true);
+        }
+        mIsInRecentsViewVisibleState = state.isRecentsViewVisible();
     }
 
     @Override


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/6919
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/6872

Two bugs reproduce only when the default home is a third-party launcher. When a third-party launcher is used, Overview is hosted by Launcher3's fallback recents path instead of by QuickstepLauncher.

Bug A: Tapping "App info" from the overview task menu leaves a stuck TaskMenuView floating over recents until the host dies. See https://github.com/GrapheneOS/os-issue-tracker/issues/6872

Bug B: Backing out of the launched activity lands on fallback recents first, so the user needs a second back press to reach home. There may be floating task icon chips with no Activity preview as seen in https://github.com/GrapheneOS/os-issue-tracker/issues/6919)

The fallback host has two forms:
- RecentsActivity, a real activity with its own task.
- RecentsWindowManager, a system overlay window used when enableFallbackOverviewInWindow is enabled.

Both bugs originate in shared code. SystemShortcut.AppInfo#onClick (in src/com/android/launcher3/popup/SystemShortcut.java) adds dismissTaskMenuView() to options.onEndCallback so the menu row stays visible during the launch animation.

```java
ActivityOptionsWrapper options =
        mTarget.getActivityLaunchOptions(view, mItemInfo);
// Dismiss the taskMenu when the app launch animation is complete
options.onEndCallback.add(this::dismissTaskMenuView);
PackageManagerHelper.startDetailsActivityForInfo(view.getContext(),
        mItemInfo, sourceBounds, options.toBundle());
```

That callback only fires on the first-party path. QuickstepLauncher delegates to QuickstepTransitionManager, which wires onEndCallback to the ActivityOptions animation abort/finished listeners. On either 3p host, getActivityLaunchOptions() falls through to the default ActivityContext implementation whose onEndCallback RunnableList nothing ever flushes, so the menu stays attached (bug A). RecentsActivity is a distinct activity whose rest state is BG_LAUNCHER; without any extra handling, it sits between the launched activity and the 3p home on back (bug B).

Google already addressed both bugs in the Pixel Launcher shipped with CP1A. Their fix hooks cleanup into each host's onStateSetEnd rather than into the per-launch callback. In RecentsActivity#onStateSetEnd, when the recents view is no longer visible and the activity is not already finishing, call AbstractFloatingView.closeAllOpenViews to dismiss the stuck menu (bug A) and moveTaskToBack(true) to push this task behind the third-party home (bug B).

Note that RecentsWindowManager in AOSP 16-qpr2 already matches the CP1A Pixel Launcher. Its onStateSetEnd calls hideRecentsWindow() when the recents view is not visible in the incoming state, and hideRecentsWindow() already calls AbstractFloatingView.closeAllOpenViews and sets windowRootView.visibility = GONE.

Test: manual on-device verification with first- and third-party launchers. Recents overview -> App info -> {back gesture, swiping up back to recents} from App info 

Test: 60/60 tests passing from:
```
atest Launcher3QuickStepTests --test-filter \
"com.android.quickstep.FallbackRecentsTest,"\
"com.android.quickstep.TaskAnimationManagerTest,"\
"com.android.quickstep.FallbackSwipeHandlerTestCase,"\
"com.android.quickstep.RecentsWindowSwipeHandlerTestCase,"\
"com.android.launcher3.taskbar.FallbackTaskbarUIControllerTest"
```
(Using `--test-filter` prevents atest from needing to search for every class)
(These tests cannot be run until the PR https://github.com/GrapheneOS/platform_packages_apps_Launcher3/pull/72 is merged)