### PR TITLE
rewrite of the commit "allapps: hide A-Z apps list when search field is focused" to only trigger on click

### DIFF
--- a/src/com/android/launcher3/allapps/search/AppsSearchContainerLayout.java
+++ b/src/com/android/launcher3/allapps/search/AppsSearchContainerLayout.java
@@ -46,7 +46,6 @@ import com.android.launcher3.search.SearchCallback;
 import com.android.launcher3.views.ActivityContext;
 
 import java.util.ArrayList;
-import java.util.Collections;
 
 /**
  * Layout to contain the All-apps search UI.
@@ -98,14 +97,6 @@ public class AppsSearchContainerLayout extends ExtendedEditText
 
             @Override
             public void afterTextChanged(Editable s) {
-            }
-        });
-
-        addOnFocusChangeListener((v, hasFocus) -> {
-            if (hasFocus && !mIsSearchSessionActive) {
-                mIsSearchSessionActive = true;
-                // non-null list to trigger animateToSearchState
-                mAppsView.setSearchResults(Collections.emptyList());
             }
         });
 

--- a/src/com/android/launcher3/allapps/search/AppsSearchContainerLayout.java
+++ b/src/com/android/launcher3/allapps/search/AppsSearchContainerLayout.java
@@ -33,6 +33,7 @@ import android.util.AttributeSet;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup.MarginLayoutParams;
+import android.view.inputmethod.InputMethodManager;
 
 import com.android.launcher3.DeviceProfile;
 import com.android.launcher3.ExtendedEditText;
@@ -46,6 +47,7 @@ import com.android.launcher3.search.SearchCallback;
 import com.android.launcher3.views.ActivityContext;
 
 import java.util.ArrayList;
+import java.util.Collections;
 
 /**
  * Layout to contain the All-apps search UI.
@@ -102,6 +104,16 @@ public class AppsSearchContainerLayout extends ExtendedEditText
 
         mContentOverlap =
                 getResources().getDimensionPixelSize(R.dimen.all_apps_search_bar_content_overlap);
+    }
+
+    @Override
+    protected void viewClicked(InputMethodManager imm) {
+        super.viewClicked(imm);
+        if (!mIsSearchSessionActive) {
+            mIsSearchSessionActive = true;
+            // non-null list to trigger animateToSearchState
+            mAppsView.setSearchResults(Collections.emptyList());
+        }
     }
 
     @Override


### PR DESCRIPTION
The revert is done to rewrite the commit message.

This aligns the search UX with stock OS + widgets search.

The previous implementation of this commit using OnFocusChangeListener in AppsSearchContainerLayout
fired on any requestFocus() call, including programmatic ones. This broke the test
KeyboardFocusTest#testAllAppsExitSearchAndFocusApp. Focusing the search view triggered
setSearchResults(emptyList()) and made isSearching() true, so getActiveRecyclerView() returned the
empty SearchRecyclerView and DPAD_DOWN had no app to focus.

We now override viewClicked(InputMethodManager), which is TextView's lifecycle hook for a user
activating an editable text field. It's called on the first tap into the field (unlike performClick
which View#onTouchEvent skips when a focusable-in-touch-mode view is newly focused). A11y
ACTION_CLICK against an editable TextView also routes through viewClicked via
TextView#performAccessibilityActionClick, so the single override covers both touch and
accessibility paths.

Programmatic requestFocus() and keyboard navigation to the search field no longer start a session
and hides the all apps A-Z list, which restores the intended behavior exercised by
testAllAppsExitSearchAndFocusApp. Typing-to-search still starts a session via the existing
TextWatcher. This is probably useful if we add an option to open keyboard automatically when the all
apps drawer is open like stock OS.

This mirrors NexusLauncher's SearchEditText, which overrides viewClicked and routes into the same
search session start path that its UniversalSearchInputView OnClickListener uses.

Test: manual, tap on all apps search bar and confirm all apps list disappears
Test: atest Launcher3QuickStepTests:com.android.launcher3.allapps.KeyboardFocusTest#testAllAppsExitSearchAndFocusApp (this test cannot be run until PR https://github.com/GrapheneOS/platform_packages_apps_Launcher3/pull/72 is merged)