### PR TITLE
add Launcher3QuickStepTests

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -662,6 +662,35 @@ android_app {
 
 }
 
+// Launcher3QuickStep with R8 optimization disabled so that instrumentation tests can access all
+// methods. The production Launcher3QuickStep has R8 enabled, which strips methods that are unused
+// by the app but referenced by tests (e.g. @JvmOverloads synthetic overloads, default interface
+// methods).
+android_app {
+    name: "Launcher3QuickStepForTesting",
+    static_libs: ["Launcher3QuickStepLib"],
+    optimize: {
+        enabled: false,
+    },
+
+    platform_apis: true,
+    min_sdk_version: "current",
+    target_sdk_version: "current",
+
+    privileged: true,
+    system_ext_specific: true,
+
+    resource_dirs: ["quickstep/res"],
+
+    additional_manifests: [
+        "quickstep/AndroidManifest-launcher.xml",
+        "quickstep/AndroidManifest-testing.xml",
+        "AndroidManifest-common.xml",
+    ],
+
+    manifest: "quickstep/AndroidManifest.xml",
+}
+
 // Build rule for Launcher3 Go app with quickstep for Android Go devices.
 // Note that the following two rules are exactly same, and should
 // eventually be merged into a single target

--- a/README.md
+++ b/README.md
@@ -23,3 +23,31 @@ Some tests such as `NavHandleLongPressHandlerTest`, `NavHandleLongPressInputCons
 (`quickstep/tests/multivalentTests/src/com/android/quickstep/util/TestExtensions.kt`),
 which calls `Assume.assumeTrue(BuildConfig.IS_DEBUG_DEVICE)`. To exercise them, set 
 `IS_DEBUG_DEVICE = true` in `src_build_config/com/android/launcher3/BuildConfig.java`
+
+### Known test failures (WIP)
+
+With bluejay (Pixel 6a) and `IS_DEBUG_DEVICE = true`, totals: 2392 passed, 494 assumption failed, 11 
+failed, 3 ignored. 
+
+Some of these failures are due to hardcoded Google apps in expectations (e.g. 
+`com.android.launcher3.model.LoaderTaskTest#loadsDataProperly`), and other failures are due to flaky
+leak detection. Other failures are unknown
+
+The 11 failures can be run with
+
+```bash
+atest Launcher3QuickStepTests --test-filter \
+"com.android.launcher3.allapps.TaplAllAppsIconsWorkingTest#testAppIconLaunchFromAllAppsFromHome,"\
+"com.android.launcher3.dragging.TaplUninstallRemoveTest#testAddDeleteShortcutOnHotseat,"\
+"com.android.launcher3.model.LoaderTaskTest#loadsDataProperly,"\
+"com.android.launcher3.model.gridmigration.ValidGridMigrationUnitTest#runExtensiveTestCases,"\
+"com.android.launcher3.util.LayoutImportExportHelperTest#exportWidgetFromWorkspace,"\
+"com.android.launcher3.workspace.TaplWorkspaceTest#testAddAndDeletePageAndFling,"\
+"com.android.launcher3.workspace.TaplWorkspaceTest#testWorkspace,"\
+"com.android.quickstep.InputConsumerUtilsTest#testNewBaseConsumer_nonTrackpadMouseEvent_desktop_returnsDefaultInputConsumer,"\
+"com.android.quickstep.TaplOverviewIconTest#testSplitTaskTapBothIconMenus,"\
+"com.android.quickstep.TaplOverviewIconTest#testOverviewActionsMenu,"\
+"com.android.quickstep.TaplStartLauncherViaGestureTests#testStressPressOverview"
+```
+
+See https://github.com/GrapheneOS/platform_packages_apps_Launcher3/pull/72 for stacktraces

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Launcher3
+
+## Running Launcher3QuickStepTests
+
+This will run the QuickStep test files that are left in AOSP (used by Google's Pixel Launcher, 
+NexusLauncher). This module also includes the regular Launcher3 tests:
+
+```
+atest Launcher3QuickStepTests
+```
+
+Launcher3QuickStepTests will put the device into test harness mode which is currently seems to only 
+be removable by a factory reset.
+
+The TAPL tests require you to not touch the screen at all.
+
+The test APK is wired via `instrumentation_for: "Launcher3QuickStepForTesting"` in 
+`quickstep/Android.bp`, so the tests run against the `Launcher3QuickStepForTesting` target (variant 
+of `Launcher3QuickStep` that's debuggable and has `optimize` disabled).
+
+Some tests such as `NavHandleLongPressHandlerTest`, `NavHandleLongPressInputConsumerTest`, and 
+`ContextualSearchInvokerTest` are gated by `TestExtensions.overrideNavConfigFlag`
+(`quickstep/tests/multivalentTests/src/com/android/quickstep/util/TestExtensions.kt`),
+which calls `Assume.assumeTrue(BuildConfig.IS_DEBUG_DEVICE)`. To exercise them, set 
+`IS_DEBUG_DEVICE = true` in `src_build_config/com/android/launcher3/BuildConfig.java`

--- a/quickstep/Android.bp
+++ b/quickstep/Android.bp
@@ -109,3 +109,51 @@ filegroup {
         "tests/multivalentScreenshotTests/src/**/*.kt",
     ],
 }
+
+android_test {
+    name: "Launcher3QuickStepTests",
+    defaults: [
+        "launcher_compose_tests_defaults",
+    ],
+    srcs: [
+        ":launcher3-quickstep-tests-src",
+        ":launcher-tests-src",
+    ],
+    exclude_srcs: [
+        // widget_picker_component is a static_lib of both the test APK and the instrumented
+        // app. Each gets its own AAPT2 resource compilation with different ID namespaces, so
+        // the test APK's widgetpicker R class shadows the app's with wrong resource IDs.
+        // TaplAddWidgetTest triggers the widget picker UI which hits this mismatch.
+        // Same exclusion as Launcher3Tests -- see tests/Android.bp.
+        "../tests/src_e2e/com/android/launcher3/widget/TaplAddWidgetTest.java",
+    ],
+    static_libs: [
+        "Launcher3TestLib",
+        "com_android_launcher3_flags_lib",
+        "com_android_wm_shell_flags_lib",
+        "com_android_systemui_shared_flags_lib",
+        "androidx.core_core-animation-testing",
+    ],
+    // android_test defaults resource_dirs to ["res"] when a local res/ exists. In quickstep that
+    // would package app quickstep/res into the test APK, recreating the com.android.launcher3.R
+    // shadowing / resource ID mismatch against the instrumented Launcher3QuickStep app.
+    resource_dirs: [],
+    libs: [
+        "android.test.base.stubs.system",
+        "android.test.runner.stubs.system",
+        "android.test.mock.stubs.system",
+    ],
+    jni_libs: [
+        "libdexmakerjvmtiagent",
+        "libstaticjvmtiagent",
+    ],
+    use_embedded_native_libs: false,
+    compile_multilib: "both",
+    instrumentation_for: "Launcher3QuickStepForTesting",
+    manifest: "tests/AndroidManifest.xml",
+    platform_apis: true,
+    test_config: "tests/Launcher3QuickStepTests.xml",
+    data: [":Launcher3QuickStepForTesting"],
+    plugins: ["dagger2-compiler"],
+    test_suites: ["general-tests"],
+}

--- a/quickstep/AndroidManifest-testing.xml
+++ b/quickstep/AndroidManifest-testing.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Sets debuggable so that the JVMTI agent required by mockito's inline mock maker
+     can attach to the instrumentation test process. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.launcher3">
+    <application android:debuggable="true" />
+</manifest>

--- a/quickstep/tests/AndroidManifest.xml
+++ b/quickstep/tests/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.android.launcher3.tests">
+
+    <uses-sdk android:targetSdkVersion="29" android:minSdkVersion="25"
+              tools:overrideLibrary="android.support.test.uiautomator.v18"/>
+
+    <application android:debuggable="true">
+        <uses-library android:name="android.test.runner" />
+        <activity android:name="platform.test.screenshot.ScreenshotActivity" android:exported="true"/>
+    </application>
+
+    <instrumentation
+        android:functionalTest="false"
+        android:handleProfiling="false"
+        android:name="androidx.test.runner.AndroidJUnitRunner"
+        android:targetPackage="com.android.launcher3" >
+        <meta-data android:name="listener"
+            android:value="com.android.launcher3.util.GlobalTestRunListener"/>
+    </instrumentation>
+</manifest>

--- a/quickstep/tests/Launcher3QuickStepTests.xml
+++ b/quickstep/tests/Launcher3QuickStepTests.xml
@@ -35,6 +35,15 @@
 
         <option name="run-command" value="settings put global verifier_verify_adb_installs 0" />
 
+        <!-- GrapheneOS: bypass fs-verity and same-versionCode checks for test installs -->
+        <option name="run-command" value="setprop persist.disable_install_time_fsverity_check true" />
+        <option name="run-command" value="setprop persist.disable_same_versionCode_sys_pkg_update_check true" />
+        <option name="run-command" value="setprop persist.allow_unknown_system_app_updates 1" />
+
+        <!-- GrapheneOS: allow weakening DCL restrictions for debuggable system apps (mockito needs dexmaker) -->
+        <option name="run-command" value="setprop persist.sys.allow_weakening_system_app_sepolicy true" />
+        <option name="run-command" value="pm edit-gos-package-state com.android.launcher3 0 add-flag RESTRICT_STORAGE_DYN_CODE_LOADING_NON_DEFAULT clear-flag RESTRICT_STORAGE_DYN_CODE_LOADING set-kill-uid-after-apply true" />
+
         <!-- Kill the launcher so it starts fresh. TestLogging.sHadEventsNotFromTest is a
              static boolean that never resets; a stale launcher process from before the test
              run may already have it set, which causes every TAPL test to fail.
@@ -42,6 +51,20 @@
              (deviceId != -1) will set this flag and fail all subsequent TAPL tests. -->
         <option name="run-command" value="am force-stop com.android.launcher3" />
 
+    </target_preparer>
+
+    <!-- GrapheneOS: restore hardening after tests. Test harness mode (set-test-harness above)
+         wants you to factory rest to get out of the test harness mode anyway. But can still use
+         device eleewhere in test harness mode from a previous run, so explicit teardown still nice
+         for these persist properties. Test harness mode is required regardless: without it, 
+         TestInformationProvider.getProxy() returns null and all TAPL test communication with the 
+         launcher process dies. -->
+    <target_preparer class="com.android.tradefed.targetprep.RunCommandTargetPreparer">
+        <option name="teardown-command" value="setprop persist.disable_install_time_fsverity_check ''" />
+        <option name="teardown-command" value="setprop persist.disable_same_versionCode_sys_pkg_update_check ''" />
+        <option name="teardown-command" value="setprop persist.allow_unknown_system_app_updates ''" />
+        <option name="teardown-command" value="setprop persist.sys.allow_weakening_system_app_sepolicy ''" />
+        <option name="teardown-command" value="pm edit-gos-package-state com.android.launcher3 0 clear-flag RESTRICT_STORAGE_DYN_CODE_LOADING_NON_DEFAULT clear-flag RESTRICT_STORAGE_DYN_CODE_LOADING set-kill-uid-after-apply true" />
     </target_preparer>
 
     <target_preparer class="com.android.tradefed.targetprep.suite.SuiteApkInstaller">

--- a/quickstep/tests/Launcher3QuickStepTests.xml
+++ b/quickstep/tests/Launcher3QuickStepTests.xml
@@ -42,6 +42,14 @@
 
         <!-- GrapheneOS: allow weakening DCL restrictions for debuggable system apps (mockito needs dexmaker) -->
         <option name="run-command" value="setprop persist.sys.allow_weakening_system_app_sepolicy true" />
+
+        <!-- Suppress the 16KB page size compatibility warning dialog on certain devices (e.g. 
+             bluejay/Pixel 6a). The test APK bundles dexmaker JVMTI agent libraries (
+             libstaticjvmtiagent.so, libdexmakerjvmtiagent.so) whose ELF LOAD
+             segments are not 16KB-aligned. Without this, Android pops a system alert dialog
+             mid-test ("Android App Compatibility"), which TAPL detects as an anomaly and
+             fails all tests that trigger it. See AppWarnings.showPageSizeMismatchDialogIfNeeded. -->
+        <option name="run-command" value="setprop bionic.linker.16kb.app_compat.enabled true" />
         <option name="run-command" value="pm edit-gos-package-state com.android.launcher3 0 add-flag RESTRICT_STORAGE_DYN_CODE_LOADING_NON_DEFAULT clear-flag RESTRICT_STORAGE_DYN_CODE_LOADING set-kill-uid-after-apply true" />
 
         <!-- Kill the launcher so it starts fresh. TestLogging.sHadEventsNotFromTest is a

--- a/quickstep/tests/Launcher3QuickStepTests.xml
+++ b/quickstep/tests/Launcher3QuickStepTests.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration description="Runs Launcher3 QuickStep tests.">
+    <option name="test-suite-tag" value="apct" />
+    <option name="test-suite-tag" value="apct-instrumentation" />
+
+    <option name="max-tmp-logcat-file" value="104857600" /> <!-- 100 * 1024 * 1024 -->
+
+    <logger class="com.android.tradefed.log.FileLogger">
+        <option name="max-log-size" value="20" />
+    </logger>
+
+    <target_preparer class="com.android.tradefed.targetprep.DeviceSetup">
+        <option name="set-test-harness" value="true" />
+
+        <option name="run-command" value="svc nfc disable" />
+        <option name="run-command" value="settings put global ble_scan_always_enabled 0" />
+        <option name="run-command" value="svc bluetooth disable" />
+
+        <option name="run-command" value="pm uninstall com.google.android.apps.nexuslauncher" />
+        <option name="run-command" value="pm uninstall com.google.android.apps.nexuslauncher.out_of_proc_tests" />
+        <option name="run-command" value="pm uninstall com.google.android.apps.nexuslauncher.tests" />
+        <option name="run-command" value="pm disable com.google.android.googlequicksearchbox" />
+
+        <option name="run-command" value="input keyevent 82" />
+        <option name="run-command" value="settings delete secure assistant" />
+        <option name="run-command" value="settings put global airplane_mode_on 1" />
+        <option name="run-command" value="am broadcast -a android.intent.action.AIRPLANE_MODE" />
+
+        <option name="run-command" value="setprop debug.wm.disable_deprecated_target_sdk_dialog 1"/>
+
+        <option name="run-command" value="settings put system pointer_location 1" />
+        <option name="run-command" value="settings put system show_touches 1" />
+
+        <option name="run-command" value="setprop pixel_legal_joint_permission_v2 true" />
+
+        <option name="run-command" value="settings put global verifier_verify_adb_installs 0" />
+
+        <!-- Kill the launcher so it starts fresh. TestLogging.sHadEventsNotFromTest is a
+             static boolean that never resets; a stale launcher process from before the test
+             run may already have it set, which causes every TAPL test to fail.
+             Also: do not tap the screen at all during tests, as any physical input event
+             (deviceId != -1) will set this flag and fail all subsequent TAPL tests. -->
+        <option name="run-command" value="am force-stop com.android.launcher3" />
+
+    </target_preparer>
+
+    <target_preparer class="com.android.tradefed.targetprep.suite.SuiteApkInstaller">
+        <option name="cleanup-apks" value="true" />
+        <option name="test-file-name" value="Launcher3QuickStepTests.apk" />
+        <option name="test-file-name" value="Launcher3QuickStepForTesting.apk" />
+    </target_preparer>
+
+
+    <metrics_collector class="com.android.tradefed.device.metric.FilePullerLogCollector">
+        <option name="directory-keys" value="/data/user/0/com.android.launcher3/files" />
+        <option name="directory-keys" value="/data/user/10/com.android.launcher3/files" />
+        <option name="collect-on-run-ended-only" value="true" />
+    </metrics_collector>
+
+    <test class="com.android.tradefed.testtype.AndroidJUnitTest" >
+        <option name="package" value="com.android.launcher3.tests" />
+        <option name="runner" value="androidx.test.runner.AndroidJUnitRunner" />
+        <option name="hidden-api-checks" value="false" />
+    </test>
+</configuration>

--- a/quickstep/tests/multivalentTests/src/com/android/launcher3/taskbar/bubbles/DragToBubbleControllerTest.kt
+++ b/quickstep/tests/multivalentTests/src/com/android/launcher3/taskbar/bubbles/DragToBubbleControllerTest.kt
@@ -21,6 +21,8 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Insets
 import android.graphics.Rect
+import android.platform.test.annotations.EnableFlags
+import android.platform.test.flag.junit.SetFlagsRule
 import android.widget.FrameLayout
 import androidx.core.animation.AnimatorTestRule
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
@@ -32,6 +34,7 @@ import com.android.launcher3.DropTarget.DragObject
 import com.android.launcher3.dragndrop.DragOptions
 import com.android.launcher3.model.data.AppInfo
 import com.android.launcher3.taskbar.bubbles.BubbleBarController.BubbleBarLocationListener
+import com.android.wm.shell.Flags.FLAG_ENABLE_CREATE_ANY_BUBBLE
 import com.android.wm.shell.shared.bubbles.BubbleBarLocation
 import com.android.wm.shell.shared.bubbles.DeviceConfig
 import com.android.wm.shell.shared.bubbles.DragZoneFactory
@@ -61,6 +64,7 @@ import org.mockito.kotlin.verify
 class DragToBubbleControllerTest {
 
     @get:Rule val animatorTestRule = AnimatorTestRule()
+    @get:Rule val mSetFlagsRule: SetFlagsRule = SetFlagsRule()
 
     private val context = getApplicationContext<Context>()
     private val container = FrameLayout(context)
@@ -484,6 +488,7 @@ class DragToBubbleControllerTest {
     }
 
     @Test
+    @EnableFlags(FLAG_ENABLE_CREATE_ANY_BUBBLE)
     fun onShellDragStateChanged_true_preparesShellDragManager() {
         // When
         dragToBubbleController.onShellDragStateChanged(true)
@@ -512,6 +517,7 @@ class DragToBubbleControllerTest {
     }
 
     @Test
+    @EnableFlags(FLAG_ENABLE_CREATE_ANY_BUBBLE)
     fun showShellBubbleBarDropTargetAt_leftLocation_showsLeftDropTarget() {
         // Given
         dragToBubbleController.onShellDragStateChanged(true)
@@ -526,6 +532,7 @@ class DragToBubbleControllerTest {
     }
 
     @Test
+    @EnableFlags(FLAG_ENABLE_CREATE_ANY_BUBBLE)
     fun showShellBubbleBarDropTargetAt_rightLocation_showsRightDropTarget() {
         // Given
         dragToBubbleController.onShellDragStateChanged(true)
@@ -540,6 +547,7 @@ class DragToBubbleControllerTest {
     }
 
     @Test
+    @EnableFlags(FLAG_ENABLE_CREATE_ANY_BUBBLE)
     fun showShellBubbleBarDropTargetAtLeft_nullLocation_hidesDropTarget() {
         // Given
         dragToBubbleController.onShellDragStateChanged(true)
@@ -581,6 +589,7 @@ class DragToBubbleControllerTest {
     }
 
     @Test
+    @EnableFlags(FLAG_ENABLE_CREATE_ANY_BUBBLE)
     fun showShellBubbleBarDropTargetAt_consecutiveCallsSameLocation_noCallsToListener() {
         // Given
         prepareBubbleBarViewController(bubbleBarLocation = BubbleBarLocation.LEFT)
@@ -643,6 +652,7 @@ class DragToBubbleControllerTest {
     }
 
     @Test
+    @EnableFlags(FLAG_ENABLE_CREATE_ANY_BUBBLE)
     fun isDragInProgress_afterShellDragStart_returnsTrue() {
         // When
         dragToBubbleController.onShellDragStateChanged(true)

--- a/quickstep/tests/multivalentTests/src/com/android/quickstep/inputconsumers/NavHandleLongPressHandlerTest.java
+++ b/quickstep/tests/multivalentTests/src/com/android/quickstep/inputconsumers/NavHandleLongPressHandlerTest.java
@@ -38,6 +38,7 @@ import com.android.quickstep.util.ContextualSearchInvoker;
 import com.android.quickstep.util.ContextualSearchStateManager;
 import com.android.quickstep.util.TestExtensions;
 
+import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -76,6 +77,8 @@ public class NavHandleLongPressHandlerTest {
             mLongPressHandler.startNavBarAnimation(mNavHandle);
             verify(mNavHandle, never())
                     .animateNavBarLongPress(anyBoolean(), anyBoolean(), anyLong());
+        } catch (AssumptionViolatedException e) {
+            throw e;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -86,6 +89,8 @@ public class NavHandleLongPressHandlerTest {
         try (AutoCloseable flag = overrideAnimateLPNHFlag(true)) {
             mLongPressHandler.startNavBarAnimation(mNavHandle);
             verify(mNavHandle).animateNavBarLongPress(anyBoolean(), anyBoolean(), anyLong());
+        } catch (AssumptionViolatedException e) {
+            throw e;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/quickstep/tests/multivalentTests/src/com/android/quickstep/inputconsumers/NavHandleLongPressInputConsumerTest.java
+++ b/quickstep/tests/multivalentTests/src/com/android/quickstep/inputconsumers/NavHandleLongPressInputConsumerTest.java
@@ -71,6 +71,7 @@ import dagger.BindsInstance;
 import dagger.Component;
 
 import org.junit.After;
+import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -248,6 +249,8 @@ public class NavHandleLongPressInputConsumerTest {
             verify(mNavHandleLongPressHandler, never()).onTouchFinished(any(), any());
             verify(mStatsLogger).log(LAUNCHER_LONG_PRESS_NAVBAR);
             verifyNoMoreInteractions(mStatsLatencyLogger);
+        } catch (AssumptionViolatedException e) {
+            throw e;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -269,6 +272,8 @@ public class NavHandleLongPressInputConsumerTest {
             verify(mNavHandleLongPressHandler, never()).onTouchFinished(any(), any());
             verify(mStatsLogger).log(LAUNCHER_LONG_PRESS_NAVBAR);
             verifyNoMoreInteractions(mStatsLatencyLogger);
+        } catch (AssumptionViolatedException e) {
+            throw e;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -454,6 +459,8 @@ public class NavHandleLongPressInputConsumerTest {
                     eq(NavHandleLongPressInputConsumer.CANCEL_REASON_TOUCH_SLOP_PASSED));
             verifyNoMoreInteractions(mStatsLogger);
             verify(mStatsLatencyLogger).log(LAUNCHER_LATENCY_CONTEXTUAL_SEARCH_LPNH_ABANDON);
+        } catch (AssumptionViolatedException e) {
+            throw e;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -491,6 +498,8 @@ public class NavHandleLongPressInputConsumerTest {
                     eq(NavHandleLongPressInputConsumer.CANCEL_REASON_TOUCH_SLOP_PASSED));
             verifyNoMoreInteractions(mStatsLogger);
             verify(mStatsLatencyLogger).log(LAUNCHER_LATENCY_CONTEXTUAL_SEARCH_LPNH_ABANDON);
+        } catch (AssumptionViolatedException e) {
+            throw e;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/quickstep/tests/multivalentTests/src/com/android/quickstep/logging/SettingsChangeLoggerTest.kt
+++ b/quickstep/tests/multivalentTests/src/com/android/quickstep/logging/SettingsChangeLoggerTest.kt
@@ -26,7 +26,6 @@ import com.android.launcher3.graphics.ThemeManager
 import com.android.launcher3.logging.InstanceId
 import com.android.launcher3.logging.StatsLogManager
 import com.android.launcher3.logging.StatsLogManager.LauncherEvent.LAUNCHER_ADD_NEW_APPS_TO_HOME_SCREEN_ENABLED
-import com.android.launcher3.logging.StatsLogManager.LauncherEvent.LAUNCHER_ALL_APPS_SUGGESTIONS_ENABLED
 import com.android.launcher3.logging.StatsLogManager.LauncherEvent.LAUNCHER_HOME_SCREEN_ROTATION_DISABLED
 import com.android.launcher3.logging.StatsLogManager.LauncherEvent.LAUNCHER_HOME_SCREEN_ROTATION_ENABLED
 import com.android.launcher3.logging.StatsLogManager.LauncherEvent.LAUNCHER_HOME_SCREEN_SUGGESTIONS_ENABLED
@@ -90,11 +89,14 @@ class SettingsChangeLoggerTest {
     fun loggingPrefs_correctDefaultValue() {
         val systemUnderTest = SettingsChangeLogger.INSTANCE.get(context)
 
+        // GrapheneOS: AOSP launcher_preferences.xml only declares pref_icon_badging,
+        // pref_add_icon_to_home, and pref_allowRotation. Upstream originally also asserted
+        // OVERVIEW_SUGGESTED_ACTIONS ("pref_overview_action_suggestions") and
+        // KEY_ENABLE_MINUS_ONE ("pref_enable_minus_one"), which only exist in the
+        // Pixel Launcher (NexusLauncher) build's launcher_preferences.xml, not in AOSP.
         assertThat(systemUnderTest.loggingPrefs[ALLOW_ROTATION_PREFERENCE_KEY]!!.defaultValue)
             .isFalse()
         assertThat(systemUnderTest.loggingPrefs[ADD_ICON_PREFERENCE_KEY]!!.defaultValue).isTrue()
-        assertThat(systemUnderTest.loggingPrefs[OVERVIEW_SUGGESTED_ACTIONS]!!.defaultValue).isTrue()
-        assertThat(systemUnderTest.loggingPrefs[KEY_ENABLE_MINUS_ONE]!!.defaultValue).isTrue()
     }
 
     @Test
@@ -125,24 +127,20 @@ class SettingsChangeLoggerTest {
     }
 
     private fun verifyDefaultEvent(capturedEvents: MutableList<StatsLogManager.EventEnum>) {
+        // GrapheneOS: LAUNCHER_ALL_APPS_SUGGESTIONS_ENABLED (619) and
+        // LAUNCHER_GOOGLE_APP_SWIPE_LEFT_ENABLED (617) are only emitted by the
+        // Pixel Launcher (NexusLauncher) build, which declares the
+        // pref_overview_action_suggestions and pref_enable_minus_one keys in
+        // its own launcher_preferences.xml. AOSP Launcher3's
+        // launcher_preferences.xml does not declare those prefs.
         assertThat(capturedEvents.any { it.id == LAUNCHER_NOTIFICATION_DOT_ENABLED.id }).isTrue()
         assertThat(capturedEvents.any { it.id == LAUNCHER_NAVIGATION_MODE_GESTURE_BUTTON.id })
             .isTrue()
         assertThat(capturedEvents.any { it.id == LAUNCHER_THEMED_ICON_DISABLED.id }).isTrue()
         assertThat(capturedEvents.any { it.id == LAUNCHER_ADD_NEW_APPS_TO_HOME_SCREEN_ENABLED.id })
             .isTrue()
-        assertThat(capturedEvents.any { it.id == LAUNCHER_ALL_APPS_SUGGESTIONS_ENABLED.id })
-            .isTrue()
         assertThat(capturedEvents.any { it.id == LAUNCHER_HOME_SCREEN_SUGGESTIONS_ENABLED.id })
             .isTrue()
-        assertThat(capturedEvents.any { it.id == LAUNCHER_GOOGLE_APP_SWIPE_LEFT_ENABLED }).isTrue()
-    }
-
-    companion object {
-        private const val KEY_ENABLE_MINUS_ONE = "pref_enable_minus_one"
-        private const val OVERVIEW_SUGGESTED_ACTIONS = "pref_overview_action_suggestions"
-
-        private const val LAUNCHER_GOOGLE_APP_SWIPE_LEFT_ENABLED = 617
     }
 
     @LauncherAppSingleton

--- a/quickstep/tests/multivalentTests/src/com/android/quickstep/util/ContextualSearchInvokerTest.java
+++ b/quickstep/tests/multivalentTests/src/com/android/quickstep/util/ContextualSearchInvokerTest.java
@@ -57,6 +57,7 @@ import com.android.quickstep.TopTaskTracker;
 import com.android.quickstep.views.RecentsView;
 import com.android.quickstep.views.RecentsViewContainer;
 
+import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -204,6 +205,8 @@ public class ContextualSearchInvokerTest {
             verify(mMockContextualSearchManager).startContextualSearch(
                     eq(CONTEXTUAL_SEARCH_ENTRY_POINT), any());
             verifyNoMoreInteractions(mMockStatsLogManager);
+        } catch (AssumptionViolatedException e) {
+            throw e;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -219,6 +222,8 @@ public class ContextualSearchInvokerTest {
             verify(mMockContextualSearchManager).startContextualSearch(
                     eq(CONTEXTUAL_SEARCH_ENTRY_POINT), any());
             verifyNoMoreInteractions(mMockStatsLogManager);
+        } catch (AssumptionViolatedException e) {
+            throw e;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -238,6 +243,8 @@ public class ContextualSearchInvokerTest {
             verify(mMockContextualSearchManager).startContextualSearch(
                     eq(CONTEXTUAL_SEARCH_ENTRY_POINT), any());
             verifyNoMoreInteractions(mMockStatsLogManager);
+        } catch (AssumptionViolatedException e) {
+            throw e;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -258,6 +265,8 @@ public class ContextualSearchInvokerTest {
             verify(mMockContextualSearchManager).startContextualSearch(
                     eq(CONTEXTUAL_SEARCH_ENTRY_POINT), any());
             verifyNoMoreInteractions(mMockStatsLogManager);
+        } catch (AssumptionViolatedException e) {
+            throw e;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/quickstep/tests/src/com/android/quickstep/FallbackRecentsTest.java
+++ b/quickstep/tests/src/com/android/quickstep/FallbackRecentsTest.java
@@ -334,9 +334,10 @@ public class FallbackRecentsTest {
         final Matcher matcher = COMPONENT_INFO_REGEX.matcher(
                 mDevice.executeShellCommand(launcherCmdForMainUser));
         assertTrue("Incorrect output from get-default-launcher", matcher.find());
+        String testPackageName = getInstrumentation().getContext().getPackageName();
         assertEquals("Current Launcher activity is incorrect",
-                "com.google.android.apps.nexuslauncher.tests/com.android"
-                        + ".launcher3.testcomponent.TestLauncherActivity",
+                testPackageName
+                        + "/com.android.launcher3.testcomponent.TestLauncherActivity",
                 matcher.group(1)
         );
     }

--- a/src/com/android/launcher3/Utilities.java
+++ b/src/com/android/launcher3/Utilities.java
@@ -31,6 +31,8 @@ import static com.android.window.flags.Flags.enableNonDefaultDisplaySplit;
 import android.annotation.SuppressLint;
 import android.app.ActivityManager;
 import android.app.ActivityOptions;
+import android.app.ActivityThread;
+import android.app.Instrumentation;
 import android.app.Person;
 import android.app.WallpaperManager;
 import android.content.Context;
@@ -168,6 +170,13 @@ public final class Utilities {
         Configuration configuration = context.getResources().getConfiguration();
         int nightMode = configuration.uiMode & Configuration.UI_MODE_NIGHT_MASK;
         return nightMode == Configuration.UI_MODE_NIGHT_YES;
+    }
+
+    public static boolean isRunningInstrumentationTest() {
+        final var thread = ActivityThread.currentActivityThread();
+        if (thread == null) return false;
+        final Instrumentation instrumentation = thread.getInstrumentation();
+        return instrumentation != null && instrumentation.isInstrumenting();
     }
 
     private static boolean sIsRunningInTestHarness = ActivityManager.isRunningInTestHarness();

--- a/src/com/android/launcher3/allapps/PrivateProfileManager.java
+++ b/src/com/android/launcher3/allapps/PrivateProfileManager.java
@@ -695,7 +695,11 @@ public class PrivateProfileManager extends UserProfileManager {
                     + " settingsCogAlpha: " + mPrivateSpaceSettingsButton.getAlpha());
             if (!expand) {
                 // Call onAppsUpdated() because it may be canceled when this animation occurs.
-                if (!Utilities.isRunningInTestHarness()) {
+                final boolean isInTest = Utilities.isRunningInTestHarness()
+                        && (mAllApps.getContext().getApplicationInfo().flags
+                                & android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE) != 0
+                        && Utilities.isRunningInstrumentationTest();
+                if (!isInTest) {
                     mAllApps.getPersonalAppList().onAppsUpdated();
                 }
                 if (isPrivateSpaceHidden()) {

--- a/tests/multivalentTests/src/com/android/launcher3/model/GridSizeMigrationTest.kt
+++ b/tests/multivalentTests/src/com/android/launcher3/model/GridSizeMigrationTest.kt
@@ -23,6 +23,8 @@ import android.graphics.Point
 import android.os.Process
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
+import com.android.launcher3.BuildConfig
+import com.android.launcher3.Flags
 import com.android.launcher3.InvariantDeviceProfile
 import com.android.launcher3.LauncherPrefs
 import com.android.launcher3.LauncherPrefs.Companion.WORKSPACE_SIZE
@@ -53,6 +55,23 @@ import org.junit.runner.RunWith
 class GridSizeMigrationTest {
 
     @get:Rule val context = SandboxApplication().withModelDependency()
+
+    // Row 0 of screen 0 can be reserved for a widget (QSB = Quick Search Bar, smartspace,
+    // etc.) by two mutually exclusive mechanisms in solveGridPlacement:
+    //
+    // 1. QSB_ON_FIRST_SCREEN (legacy): a build config constant that makes
+    //    qsbOnFirstScreen() return true, which sets the placement start point to row 1.
+    //    This is false in the QuickStep build config (BuildConfig.java:27).
+    //
+    // 2. injectable_model_items (new): an aconfig flag that enables Dagger-provided items
+    //    (via extraItemsProvider / FirstRowModule in this test) to be marked as occupied
+    //    cells, blocking row 0. This replaces the hardcoded QSB_ON_FIRST_SCREEN approach.
+    //
+    // qsbOnFirstScreen() = !injectableModelItems() && QSB_ON_FIRST_SCREEN, so exactly one
+    // mechanism can be active. When neither is active, row 0 is free and items start there.
+    // See GridSizeMigrationLogic.solveGridPlacement and Utilities.qsbOnFirstScreen.
+    private val firstScreenFirstAvailableRow =
+        if (Flags.injectableModelItems() || BuildConfig.QSB_ON_FIRST_SCREEN) 1 else 0
 
     private lateinit var idp: InvariantDeviceProfile
     private lateinit var dbHelper: DatabaseHelper
@@ -191,11 +210,12 @@ class GridSizeMigrationTest {
         // 9 _ _ _
         // _ _ _ _
         assertThat(locMap.size.toLong()).isEqualTo(5)
-        assertThat(locMap[testPackage5]).isEqualTo(Point(0, 1))
-        assertThat(locMap[testPackage6]).isEqualTo(Point(1, 1))
-        assertThat(locMap[testPackage7]).isEqualTo(Point(2, 1))
-        assertThat(locMap[testPackage8]).isEqualTo(Point(3, 1))
-        assertThat(locMap[testPackage9]).isEqualTo(Point(0, 2))
+        // Point is (cellX, cellY). See firstScreenFirstAvailableRow for why row 0 may be reserved.
+        assertThat(locMap[testPackage5]).isEqualTo(Point(0, firstScreenFirstAvailableRow))
+        assertThat(locMap[testPackage6]).isEqualTo(Point(1, firstScreenFirstAvailableRow))
+        assertThat(locMap[testPackage7]).isEqualTo(Point(2, firstScreenFirstAvailableRow))
+        assertThat(locMap[testPackage8]).isEqualTo(Point(3, firstScreenFirstAvailableRow))
+        assertThat(locMap[testPackage9]).isEqualTo(Point(0, firstScreenFirstAvailableRow + 1))
     }
 
     /** Old migration logic, should be modified once is not needed anymore */
@@ -282,10 +302,11 @@ class GridSizeMigrationTest {
         // _ _ _ _
         // _ _ _ _
         assertThat(locMap.size.toLong()).isEqualTo(4)
-        assertThat(locMap[testPackage5]).isEqualTo(Triple(0, 0, 1))
-        assertThat(locMap[testPackage6]).isEqualTo(Triple(0, 1, 1))
-        assertThat(locMap[testPackage7]).isEqualTo(Triple(0, 2, 1))
-        assertThat(locMap[testPackage8]).isEqualTo(Triple(0, 3, 1))
+        // Triple is (screen, cellX, cellY). See firstScreenFirstAvailableRow for why row 0 may be reserved.
+        assertThat(locMap[testPackage5]).isEqualTo(Triple(0, 0, firstScreenFirstAvailableRow))
+        assertThat(locMap[testPackage6]).isEqualTo(Triple(0, 1, firstScreenFirstAvailableRow))
+        assertThat(locMap[testPackage7]).isEqualTo(Triple(0, 2, firstScreenFirstAvailableRow))
+        assertThat(locMap[testPackage8]).isEqualTo(Triple(0, 3, firstScreenFirstAvailableRow))
 
         // add item in B
         addItem(ITEM_TYPE_APPLICATION, 0, CONTAINER_DESKTOP, 0, 2, testPackage9)
@@ -337,8 +358,8 @@ class GridSizeMigrationTest {
         assertThat(locMap[testPackage6]).isEqualTo(Triple(0, 2, 2))
         assertThat(locMap[testPackage7]).isEqualTo(Triple(0, 4, 2))
         assertThat(locMap[testPackage8]).isEqualTo(Triple(0, 2, 3))
-        // Verify items that didn't exist in grid A are added in new screen
-        assertThat(locMap[testPackage9]).isEqualTo(Triple(0, 0, 1))
+        // testPackage9 didn't exist in grid A, so it's placed by solveGridPlacement.
+        assertThat(locMap[testPackage9]).isEqualTo(Triple(0, 0, firstScreenFirstAvailableRow))
 
         // remove item from B
         db.delete(TMP_TABLE, "$_ID=7", null)
@@ -391,9 +412,10 @@ class GridSizeMigrationTest {
         // 9 _ _ _
         // _ _ _ _
         assertThat(locMap.size.toLong()).isEqualTo(4)
-        assertThat(locMap[testPackage5]).isEqualTo(Triple(0, 0, 1))
-        assertThat(locMap[testPackage6]).isEqualTo(Triple(0, 1, 1))
-        assertThat(locMap[testPackage8]).isEqualTo(Triple(0, 3, 1))
+        // testPackage5,6,8 keep their grid B positions from the first A->B migration above.
+        assertThat(locMap[testPackage5]).isEqualTo(Triple(0, 0, firstScreenFirstAvailableRow))
+        assertThat(locMap[testPackage6]).isEqualTo(Triple(0, 1, firstScreenFirstAvailableRow))
+        assertThat(locMap[testPackage8]).isEqualTo(Triple(0, 3, firstScreenFirstAvailableRow))
         assertThat(locMap[testPackage9]).isEqualTo(Triple(0, 0, 2))
     }
 
@@ -591,7 +613,8 @@ class GridSizeMigrationTest {
         // _ _ _ _
         // _ _ _ _
         assertThat(locMap.size.toLong()).isEqualTo(1)
-        assertThat(locMap[testPackage6]).isEqualTo(Triple(0, 0, 1))
+        // Triple is (screen, cellX, cellY). See firstScreenFirstAvailableRow.
+        assertThat(locMap[testPackage6]).isEqualTo(Triple(0, 0, firstScreenFirstAvailableRow))
     }
 
     private fun migrateGrid(

--- a/tests/multivalentTests/src/com/android/launcher3/model/ShortcutIconTest.kt
+++ b/tests/multivalentTests/src/com/android/launcher3/model/ShortcutIconTest.kt
@@ -23,11 +23,13 @@ import android.graphics.Color
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.Icon
 import android.os.Process
+import android.platform.test.annotations.EnableFlags
 import android.platform.test.flag.junit.SetFlagsRule
 import android.util.Log
 import androidx.core.graphics.drawable.toDrawable
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
+import com.android.launcher3.Flags.FLAG_MODEL_REPOSITORY
 import com.android.launcher3.LauncherSettings.Favorites.ITEM_TYPE_DEEP_SHORTCUT
 import com.android.launcher3.icons.BitmapRenderer.createSoftwareBitmap
 import com.android.launcher3.icons.cache.CacheLookupFlag.Companion.DEFAULT_LOOKUP_FLAG
@@ -72,6 +74,7 @@ class ShortcutIconTest {
     val state: TestableModelState by lazy { app.appComponent.testableModelState }
 
     @Test
+    @EnableFlags(FLAG_MODEL_REPOSITORY)
     @MockUser(userType = UserIconInfo.TYPE_MAIN)
     fun shortcut_icon_retained_even_after_system_error() {
         // Setup mock LauncherApps to return a valid drawable

--- a/tests/multivalentTests/src/com/android/launcher3/util/DaggerGraphs.kt
+++ b/tests/multivalentTests/src/com/android/launcher3/util/DaggerGraphs.kt
@@ -32,8 +32,10 @@ import com.android.launcher3.dagger.SystemDragModule
 import com.android.launcher3.dagger.WidgetModule
 import com.android.launcher3.dagger.WindowManagerProxyModule
 import com.android.launcher3.util.dagger.LauncherExecutorsModule
+import com.android.launcher3.util.window.WindowManagerProxy
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 
 private class DaggerGraphs {}
 
@@ -75,3 +77,9 @@ class AllModulesMinusWMProxy
 /** All modules except the ApiWrapper */
 @Module(includes = [WindowManagerProxyModule::class, CommonModulesForTest::class])
 class AllModulesMinusApiWrapper
+
+/** Sandbox WM proxy module that provides the base WindowManagerProxy for tests */
+@Module
+class SandboxWmProxyModule {
+    @Provides fun provideWindowManagerProxy(): WindowManagerProxy = WindowManagerProxy()
+}

--- a/tests/multivalentTests/src/com/android/launcher3/util/TestConstants.java
+++ b/tests/multivalentTests/src/com/android/launcher3/util/TestConstants.java
@@ -20,11 +20,11 @@ public class TestConstants {
 
         public static final String TEST_APP_NAME = "LauncherTestApp";
         public static final String DUMMY_APP_NAME = "Aardwolf";
-        public static final String MAPS_APP_NAME = "Maps";
-        public static final String STORE_APP_NAME = "Play Store";
-        public static final String GMAIL_APP_NAME = "Gmail";
-        public static final String PHOTOS_APP_NAME = "Photos";
-        public static final String CHROME_APP_NAME = "Chrome";
-        public static final String MESSAGES_APP_NAME = "Messages";
+        public static final String MAPS_APP_NAME = "Clock";
+        public static final String STORE_APP_NAME = "Files";
+        public static final String GMAIL_APP_NAME = "Calculator";
+        public static final String PHOTOS_APP_NAME = "Phone";
+        public static final String CHROME_APP_NAME = "Contacts";
+        public static final String MESSAGES_APP_NAME = "Settings";
     }
 }

--- a/tests/multivalentTests/src/com/android/launcher3/util/rule/TestStabilityRule.java
+++ b/tests/multivalentTests/src/com/android/launcher3/util/rule/TestStabilityRule.java
@@ -155,6 +155,10 @@ public class TestStabilityRule implements TestRule {
         return getRunFlavor() == PLATFORM_PRESUBMIT;
     }
 
+    public static boolean isPostsubmit() {
+        return getRunFlavor() == PLATFORM_POSTSUBMIT;
+    }
+
     public static boolean isRobolectricTest() {
         return Build.FINGERPRINT.contains("robolectric");
     }

--- a/tests/src/com/android/launcher3/util/ui/BaseLauncherTaplTest.java
+++ b/tests/src/com/android/launcher3/util/ui/BaseLauncherTaplTest.java
@@ -117,9 +117,17 @@ public abstract class BaseLauncherTaplTest {
 
     /** Detects UI surface leaks and throws an exception if a leak is found. */
     public static void checkDetectedLeaks(LauncherInstrumentation launcher) {
-        if (TestStabilityRule.isPresubmit()) return; // b/313501215
+        if (!TestStabilityRule.isPostsubmit()) return; // b/313501215
 
         if (sUiSurfaceLeakReported) return;
+
+        // Clear references held in the test process itself before polling. launcher.forceGc()
+        // only collects inside the Launcher3 process; destroyed TestActivityContext / other
+        // test-side contexts can still be reachable from the instrumentation process. This doesn't
+        // seem to work 100% though
+        Runtime.getRuntime().gc();
+        Runtime.getRuntime().runFinalization();
+        Runtime.getRuntime().gc();
 
         // Check whether activity leak detector has found leaked activities.
         Wait.atMost(() -> getUiSurfaceLeakErrorMessage(launcher),


### PR DESCRIPTION
AOSP includes sources for quickstep tests but no actual Soong module. It appears that their closed source NexusLauncher (Pixel Launcher) consumes these quickstep test sources. You can see from some of the AOSP commits that there are references to a NexusLauncherTests in the Test: commit message trailers.

This adds the Launcher3QuickStepTests module so that these tests can actually run. More work needs to be done in order to get these tests to work, especially because some of the tests hardcode constants based on stock Pixel OS rather than AOSP (e.g., expecting the Chrome browser or the Play Store to be present). Some of the tests even hardcode the NexusLauncher package.

## Test run

Device: bluejay (Pixel 6a) on GrapheneOS

Totals: 2392 passed, 494 assumption failed, 11 failed, 3 ignored

These tests have failed and will need to be looked at later

1. `com.android.launcher3.allapps.TaplAllAppsIconsWorkingTest#testAppIconLaunchFromAllAppsFromHome`
2. `com.android.launcher3.dragging.TaplUninstallRemoveTest#testAddDeleteShortcutOnHotseat`
3. `com.android.launcher3.model.LoaderTaskTest#loadsDataProperly`
4. `com.android.launcher3.model.gridmigration.ValidGridMigrationUnitTest#runExtensiveTestCases`
5. `com.android.launcher3.util.LayoutImportExportHelperTest#exportWidgetFromWorkspace`
6. `com.android.launcher3.workspace.TaplWorkspaceTest#testAddAndDeletePageAndFling`
7. `com.android.launcher3.workspace.TaplWorkspaceTest#testWorkspace`
8. `com.android.quickstep.InputConsumerUtilsTest#testNewBaseConsumer_nonTrackpadMouseEvent_desktop_returnsDefaultInputConsumer`
9. `com.android.quickstep.TaplOverviewIconTest#testSplitTaskTapBothIconMenus`
10. `com.android.quickstep.TaplOverviewIconTest#testOverviewActionsMenu`
11. `com.android.quickstep.TaplStartLauncherViaGestureTests#testStressPressOverview`

## Stacktraces

### 1. `TaplAllAppsIconsWorkingTest#testAppIconLaunchFromAllAppsFromHome`

```
java.lang.AssertionError: Leak detector has found leaked UI surfaces; saved memory dump as an artifact. Full list of UI surfaces: QuickstepLauncher (current), TaskbarActivityContext (current), TestActivityContext (destroyed), TestActivityContext (destroyed).
	at org.junit.Assert.fail(Assert.java:89)
	at com.android.launcher3.util.Wait.atMost(Wait.kt:71)
	at com.android.launcher3.util.ui.BaseLauncherTaplTest.checkDetectedLeaks(BaseLauncherTaplTest.java:135)
	at com.android.launcher3.util.ui.PortraitLandscapeRunner$1.evaluateInPortrait(PortraitLandscapeRunner.java:111)
	at com.android.launcher3.util.ui.PortraitLandscapeRunner$1.evaluate(PortraitLandscapeRunner.java:86)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at com.android.launcher3.util.rule.ShellCommandRule$1.evaluate(ShellCommandRule.java:73)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at com.android.launcher3.util.rule.SamplerRule$2.evaluate(SamplerRule.java:137)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at android.platform.test.flag.junit.SetFlagsRule$1.evaluate(SetFlagsRule.java:220)
	at com.android.launcher3.util.rule.SkipAfterTimeOutRule$1.evaluate(SkipAfterTimeOutRule.java:42)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	...
```

### 2. `TaplUninstallRemoveTest#testAddDeleteShortcutOnHotseat`

```
java.lang.AssertionError: Unable to get a hotseat icon on 0
	at com.android.launcher3.tapl.Workspace.lambda$getHotseatAppIcon$7(Workspace.java:356)
	at com.android.launcher3.tapl.Workspace$$ExternalSyntheticLambda7.get(D8$$SyntheticClass:0)
	at java.util.Optional.orElseThrow(Optional.java:403)
	at com.android.launcher3.tapl.Workspace.getHotseatAppIcon(Workspace.java:355)
	at com.android.launcher3.dragging.TaplUninstallRemoveTest.testAddDeleteShortcutOnHotseat(TaplUninstallRemoveTest.java:171)
```

### 3. `LoaderTaskTest#loadsDataProperly`

This test seems to assume Google apps are installed

```
expected to be at least: 32
but was                : 18
	at com.android.launcher3.model.LoaderTaskTest.loadsDataProperly(LoaderTaskTest.kt:192)
```

### 4. `ValidGridMigrationUnitTest#runExtensiveTestCases`

```
org.junit.runners.model.TestTimedOutException: test timed out after 300000 milliseconds
	at java.lang.String.charAt(Native Method)
	at java.lang.String.hashCode(String.java:2304)
	at java.util.HashMap.hash(HashMap.java:337)
	at java.util.HashMap.getNode(HashMap.java:575)
	at java.util.HashMap.get(HashMap.java:563)
	at com.google.protobuf.MessageLiteToString.reflectivePrintWithIndent(MessageLiteToString.java:147)
	at com.google.protobuf.MessageLiteToString.toString(MessageLiteToString.java:49)
	at com.google.protobuf.GeneratedMessageLite.toString(GeneratedMessageLite.java:123)
	at java.lang.String.valueOf(String.java:4523)
	at java.lang.StringBuilder.append(StringBuilder.java:183)
	at com.android.launcher3.model.data.ItemInfo.dumpProperties(ItemInfo.java:335)
	at com.android.launcher3.model.data.ItemInfo.toString(ItemInfo.java:328)
	at com.android.launcher3.model.GridSizeMigrationLogic.migrateWorkspace$lambda$10(GridSizeMigrationLogic.kt:283)
	at com.android.launcher3.model.GridSizeMigrationLogic.$r8$lambda$Y4a-VBsntZtv7wkgDAtGf2-yM9o(Unknown Source:0)
	at com.android.launcher3.model.GridSizeMigrationLogic$$ExternalSyntheticLambda5.invoke(D8$$SyntheticClass:0)
	at kotlin.text.StringsKt__AppendableKt.appendElement(Appendable.kt:84)
	at kotlin.collections.CollectionsKt___CollectionsKt.joinTo(_Collections.kt:3601)
	at kotlin.collections.CollectionsKt___CollectionsKt.joinToString(_Collections.kt:3618)
	at kotlin.collections.CollectionsKt___CollectionsKt.joinToString$default(_Collections.kt:3617)
	at com.android.launcher3.model.GridSizeMigrationLogic.migrateWorkspace(GridSizeMigrationLogic.kt:283)
	at com.android.launcher3.model.gridmigration.ValidGridMigrationUnitTest.migrate(ValidGridMigrationUnitTest.kt:147)
	at com.android.launcher3.model.gridmigration.ValidGridMigrationUnitTest.runExtensiveTestCases(ValidGridMigrationUnitTest.kt:217)
```

### 5. `LayoutImportExportHelperTest#exportWidgetFromWorkspace`

```
java.lang.AssertionError
	at org.junit.Assert.fail(Assert.java:87)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at org.junit.Assert.assertTrue(Assert.java:53)
	at com.android.launcher3.util.LayoutImportExportHelperTest.importVerifyExportClearReImportVerify(LayoutImportExportHelperTest.kt:265)
	at com.android.launcher3.util.LayoutImportExportHelperTest.exportWidgetFromWorkspace(LayoutImportExportHelperTest.kt:148)
```

### 6. `TaplWorkspaceTest#testAddAndDeletePageAndFling`

```
java.lang.AssertionError: Unable to get a hotseat icon on 0
	at com.android.launcher3.tapl.Workspace.lambda$getHotseatAppIcon$7(Workspace.java:356)
	at com.android.launcher3.tapl.Workspace$$ExternalSyntheticLambda7.get(D8$$SyntheticClass:0)
	at java.util.Optional.orElseThrow(Optional.java:403)
	at com.android.launcher3.tapl.Workspace.getHotseatAppIcon(Workspace.java:355)
	at com.android.launcher3.workspace.TaplWorkspaceTest.testAddAndDeletePageAndFling(TaplWorkspaceTest.java:127)
```

### 7. `TaplWorkspaceTest#testWorkspace`

```
java.lang.AssertionError: http://go/tapl test failure: Can't find views in Launcher, id: BySelector [CLASS='\Qandroid.widget.TextView\E', PKG='\Qcom.android.launcher3\E', TEXT='\s*C\s*h\s*r\s*o\s*m\s*e\s*', FOCUSABLE='true'] in container: com.android.launcher3:id/hotseat;
Context: dragging icon to a second page of workspace to make it scrollable; now visible state is Workspace; displayId: 0
	at org.junit.Assert.fail(Assert.java:89)
	at com.android.launcher3.tapl.LauncherInstrumentation.fail(LauncherInstrumentation.java:887)
	at com.android.launcher3.tapl.LauncherInstrumentation.assertTrue(LauncherInstrumentation.java:900)
	at com.android.launcher3.tapl.LauncherInstrumentation.assertNotNull(LauncherInstrumentation.java:905)
	at com.android.launcher3.tapl.LauncherInstrumentation.waitForObjectsInContainer(LauncherInstrumentation.java:1706)
	at com.android.launcher3.tapl.LauncherInstrumentation.waitForObjectInContainer(LauncherInstrumentation.java:1696)
	at com.android.launcher3.tapl.Workspace.getHotseatAppIcon(Workspace.java:337)
	at com.android.launcher3.tapl.Workspace.ensureWorkspaceIsScrollable(Workspace.java:267)
	at com.android.launcher3.tapl.Workspace.ensureWorkspaceIsScrollable(Workspace.java:254)
	at com.android.launcher3.workspace.TaplWorkspaceTest.testWorkspace(TaplWorkspaceTest.java:82)
```

### 8. `InputConsumerUtilsTest#testNewBaseConsumer_nonTrackpadMouseEvent_desktop_returnsDefaultInputConsumer`

```
expected instance of: com.android.quickstep.inputconsumers.ResetGestureInputConsumer
but was instance of : com.android.quickstep.inputconsumers.OtherActivityInputConsumer
with value          : com.android.quickstep.inputconsumers.OtherActivityInputConsumer@aef546b
	at com.android.quickstep.InputConsumerUtilsTest.lambda$assertCorrectInputConsumer$11(InputConsumerUtilsTest.java:666)
	at com.android.quickstep.InputConsumerUtilsTest.$r8$lambda$XgNK2q0R3-AvwrfkFT_Z91M9H_0(Unknown Source:0)
	at com.android.quickstep.InputConsumerUtilsTest$$ExternalSyntheticLambda3.run(D8$$SyntheticClass:0)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:520)
	at java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at android.app.Instrumentation$SyncRunnable.run(Instrumentation.java:2663)
	at android.os.Handler.handleCallback(Handler.java:1070)
	at android.os.Handler.dispatchMessage(Handler.java:125)
	at android.os.Looper.dispatchMessage(Looper.java:333)
	at android.os.Looper.loopOnce(Looper.java:263)
	at android.os.Looper.loop(Looper.java:367)
	at android.app.ActivityThread.main(ActivityThread.java:9331)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:566)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:955)
```

### 9. `TaplOverviewIconTest#testSplitTaskTapBothIconMenus`

```
java.lang.AssertionError: http://go/tapl : successful gesture produced Mismatching events: 
>> SEQUENCE Pilfer - MISMATCH
  EXPECTED:
  | ---> (end)
  ACTUAL:
  | ---> pilferPointers
	at org.junit.Assert.fail(Assert.java:89)
	at com.android.launcher3.tapl.LauncherInstrumentation.lambda$eventsCheck$20(LauncherInstrumentation.java:2785)
	at com.android.launcher3.tapl.LauncherInstrumentation.$r8$lambda$EKIZfn89TNRGcqDaSStECScpX6c(Unknown Source:0)
	at com.android.launcher3.tapl.LauncherInstrumentation$$ExternalSyntheticLambda5.close(D8$$SyntheticClass:0)
	at com.android.launcher3.tapl.Home.switchToOverview(Home.java:58)
	at com.android.quickstep.util.SplitScreenTestUtils.clearAllRecentTasks(SplitScreenTestUtils.kt:57)
	at com.android.quickstep.util.SplitScreenTestUtils.createAndLaunchASplitPairInOverview(SplitScreenTestUtils.kt:30)
	at com.android.quickstep.TaplOverviewIconTest.testSplitTaskTapBothIconMenus(TaplOverviewIconTest.java:69)
```

### 10. `TaplOverviewIconTest#testOverviewActionsMenu`

```
java.lang.AssertionError: http://go/tapl : successful gesture produced Mismatching events: 
>> SEQUENCE Pilfer - MISMATCH
  EXPECTED:
  | ---> (end)
  ACTUAL:
  | ---> pilferPointers
	at org.junit.Assert.fail(Assert.java:89)
	at com.android.launcher3.tapl.LauncherInstrumentation.lambda$eventsCheck$20(LauncherInstrumentation.java:2785)
	at com.android.launcher3.tapl.LauncherInstrumentation.$r8$lambda$EKIZfn89TNRGcqDaSStECScpX6c(Unknown Source:0)
	at com.android.launcher3.tapl.LauncherInstrumentation$$ExternalSyntheticLambda5.close(D8$$SyntheticClass:0)
	at com.android.launcher3.tapl.Home.switchToOverview(Home.java:58)
	at com.android.quickstep.TaplOverviewIconTest.testOverviewActionsMenu(TaplOverviewIconTest.java:45)
```

### 11. `TaplStartLauncherViaGestureTests#testStressPressOverview`

```
org.junit.runners.model.TestTimedOutException: test timed out after 300000 milliseconds
	at java.lang.Object.wait(Native Method)
	at java.lang.Object.wait(Object.java:405)
	at android.app.UiAutomation.executeAndWaitForEvent(UiAutomation.java:1194)
	at com.android.launcher3.tapl.LauncherInstrumentation.executeAndWaitForEvent(LauncherInstrumentation.java:1234)
	at com.android.launcher3.tapl.LauncherInstrumentation.executeAndWaitForLauncherEvent(LauncherInstrumentation.java:1210)
	at com.android.launcher3.tapl.LauncherInstrumentation.executeAndWaitForLauncherEvent(LauncherInstrumentation.java:1200)
	at com.android.launcher3.tapl.LauncherInstrumentation.runToState(LauncherInstrumentation.java:1890)
	at com.android.launcher3.tapl.Background.goToOverviewUnchecked(Background.java:164)
	at com.android.launcher3.tapl.LaunchedAppState.switchToOverview(LaunchedAppState.java:101)
	at com.android.quickstep.TaplStartLauncherViaGestureTests.runTest(TaplStartLauncherViaGestureTests.java:92)
	at com.android.quickstep.TaplStartLauncherViaGestureTests.testStressPressOverview(TaplStartLauncherViaGestureTests.java:72)
```