### PR TITLE
Migrate old Gallery to GrapheneOS Gallery

### DIFF
--- a/src/com/android/launcher3/model/LoaderTask.java
+++ b/src/com/android/launcher3/model/LoaderTask.java
@@ -86,6 +86,7 @@ import com.android.launcher3.pm.PackageInstallInfo;
 import com.android.launcher3.pm.UserCache;
 import com.android.launcher3.pm.UserCache.CachedUserInfo;
 import com.android.launcher3.pm.UserManagerState;
+import com.android.launcher3.provider.GosLauncherDbMigrations;
 import com.android.launcher3.provider.LauncherDbUtils;
 import com.android.launcher3.shortcuts.ShortcutKey;
 import com.android.launcher3.shortcuts.ShortcutRequest;
@@ -446,6 +447,11 @@ public class LoaderTask implements Runnable {
 
         Log.d(TAG, "loadWorkspace: loading default favorites if necessary");
         dbController.loadDefaultFavoritesIfNecessary();
+        try {
+            GosLauncherDbMigrations.runIdempotentMigrations(mContext, dbController.getDb());
+        } catch (Exception e) {
+            FileLog.e(TAG, "Failed to run GrapheneOS launcher DB migrations", e);
+        }
 
         synchronized (mBgDataModel) {
             mBgDataModel.clear();

--- a/src/com/android/launcher3/provider/GosLauncherDbMigrations.kt
+++ b/src/com/android/launcher3/provider/GosLauncherDbMigrations.kt
@@ -1,0 +1,163 @@
+package com.android.launcher3.provider
+
+import android.content.ContentValues
+import android.content.Context
+import android.content.Intent
+import android.database.sqlite.SQLiteDatabase
+import androidx.annotation.VisibleForTesting
+import com.android.launcher3.ConstantItem
+import com.android.launcher3.LauncherPrefs
+import com.android.launcher3.LauncherSettings.Favorites
+import com.android.launcher3.logging.FileLog
+import com.android.launcher3.model.data.AppInfo
+import com.android.launcher3.provider.LauncherDbUtils.SQLiteTransaction
+import java.io.File
+import java.net.URISyntaxException
+
+object GosLauncherDbMigrations {
+    private const val TAG = "GrapheneOsLauncherDbMigrations"
+
+    private const val OLD_GALLERY_PACKAGE = "com.android.gallery3d"
+    private const val NEW_GALLERY_PACKAGE = "app.grapheneos.gallery"
+
+    private const val IDEMPOTENT_DB_MIGRATIONS_PREF_PREFIX =
+        "gos_launcher_idempotent_db_migrations_version"
+    private const val IN_MEMORY_DB_NAME = "memory"
+
+    private const val GALLERY_FAVORITE_MIGRATION_VERSION = 1
+
+    @JvmStatic
+    fun runIdempotentMigrations(context: Context, db: SQLiteDatabase): Int {
+        return runIdempotentMigrations(context, db) { c ->
+            getNewGalleryIntent(c)
+        }
+    }
+
+    @VisibleForTesting
+    @JvmStatic
+    fun runIdempotentMigrationsForTest(
+        context: Context,
+        db: SQLiteDatabase,
+        newGalleryIntent: Intent,
+    ): Int {
+        return runIdempotentMigrations(context, db) {
+            newGalleryIntent
+        }
+    }
+
+    @VisibleForTesting
+    @JvmStatic
+    fun clearIdempotentMigrationVersionForTest(context: Context, db: SQLiteDatabase) {
+        LauncherPrefs.get(context).removeSync(getIdempotentMigrationVersionPref(db))
+    }
+
+    private fun runIdempotentMigrations(
+        context: Context,
+        db: SQLiteDatabase,
+        newGalleryIntentProvider: (Context) -> Intent?,
+    ): Int {
+        val migrationVersionPref = getIdempotentMigrationVersionPref(db)
+        val prefs = LauncherPrefs.get(context)
+        var migrationVersion = prefs.get(migrationVersionPref)
+        var migrated = 0
+
+        if (migrationVersion < GALLERY_FAVORITE_MIGRATION_VERSION) {
+            val newGalleryIntent = newGalleryIntentProvider(context) ?: return 0
+
+            migrated += migrateGalleryFavorite(db, newGalleryIntent)
+            migrationVersion = GALLERY_FAVORITE_MIGRATION_VERSION
+            prefs.putSync(migrationVersionPref.to(migrationVersion))
+        }
+
+        return migrated
+    }
+
+    private fun getIdempotentMigrationVersionPref(db: SQLiteDatabase): ConstantItem<Int> {
+        val dbPath = db.path
+        val dbName = if (dbPath.isNullOrEmpty()) {
+            IN_MEMORY_DB_NAME
+        } else {
+            File(dbPath).name
+        }
+        return LauncherPrefs.nonRestorableItem(
+            "$IDEMPOTENT_DB_MIGRATIONS_PREF_PREFIX@$dbName",
+            0,
+        )
+    }
+
+    private fun getNewGalleryIntent(context: Context): Intent? {
+        val component = context
+            .packageManager
+            .getLaunchIntentForPackage(NEW_GALLERY_PACKAGE)
+            ?.component
+
+        if (component == null) {
+            FileLog.d(TAG, "No launch intent found for $NEW_GALLERY_PACKAGE")
+            return null
+        }
+
+        return AppInfo.makeLaunchIntent(component)
+    }
+
+    @JvmStatic
+    fun migrateGalleryFavorite(db: SQLiteDatabase, newGalleryIntent: Intent): Int {
+        val newGalleryIntentUri = newGalleryIntent.toUri(0)
+        var migrated = 0
+
+        SQLiteTransaction(db).use { transaction ->
+            db.query(
+                Favorites.TABLE_NAME,
+                arrayOf(Favorites._ID, Favorites.INTENT),
+                "${Favorites.ITEM_TYPE} = ?",
+                arrayOf(Favorites.ITEM_TYPE_APPLICATION.toString()),
+                null,
+                null,
+                null,
+            )
+                .use { cursor ->
+                    val idIndex = cursor.getColumnIndexOrThrow(Favorites._ID)
+                    val intentIndex = cursor.getColumnIndexOrThrow(Favorites.INTENT)
+                    while (cursor.moveToNext()) {
+                        if (!isOldGalleryIntent(cursor.getString(intentIndex))) {
+                            continue
+                        }
+
+                        val id = cursor.getLong(idIndex)
+                        val values = ContentValues().apply {
+                            put(Favorites.INTENT, newGalleryIntentUri)
+                        }
+                        migrated += db.update(
+                            Favorites.TABLE_NAME,
+                            values,
+                            "${Favorites._ID} = ?",
+                            arrayOf(id.toString()),
+                        )
+                    }
+                }
+            transaction.commit()
+        }
+
+        FileLog.d(TAG, "Migrated $migrated Gallery favorites")
+
+        return migrated
+    }
+
+    private fun isOldGalleryIntent(intentUri: String?): Boolean {
+        if (intentUri == null) {
+            return false
+        }
+
+        val intent = try {
+            Intent.parseUri(intentUri, 0)
+        } catch (e: URISyntaxException) {
+            FileLog.d(TAG, "Unable to parse favorite intent while migrating Gallery", e)
+            return false
+        }
+
+        if (intent.component?.packageName == OLD_GALLERY_PACKAGE) {
+            return true
+        }
+
+        return intent.`package` == OLD_GALLERY_PACKAGE
+    }
+}

--- a/tests/src/com/android/launcher3/provider/GosLauncherDbMigrationsTest.kt
+++ b/tests/src/com/android/launcher3/provider/GosLauncherDbMigrationsTest.kt
@@ -1,0 +1,248 @@
+package com.android.launcher3.provider
+
+import android.content.ComponentName
+import android.content.ContentValues
+import android.content.Context
+import android.content.Intent
+import android.database.sqlite.SQLiteDatabase
+import androidx.test.platform.app.InstrumentationRegistry
+import com.android.launcher3.LauncherSettings.Favorites
+import com.android.launcher3.model.DatabaseHelper
+import com.android.launcher3.settings.SettingsActivity
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GosLauncherDbMigrationsTest {
+    private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun migrateGalleryFavorite_updatesOnlyOldGalleryApplications() {
+        val db = TestDatabaseHelper(context).writableDatabase
+        val oldGalleryComponent = ComponentName(OLD_GALLERY_PACKAGE, OLD_GALLERY_ACTIVITY)
+        val oldGalleryComponentId = insertFavorite(
+            db,
+            Favorites.ITEM_TYPE_APPLICATION,
+            "Gallery",
+            makeLaunchIntent(oldGalleryComponent),
+        )
+        val oldGalleryPackageId = insertFavorite(
+            db,
+            Favorites.ITEM_TYPE_APPLICATION,
+            "Gallery",
+            makePackageIntent(OLD_GALLERY_PACKAGE),
+        )
+        val settingsComponent = ComponentName(
+            context.packageName,
+            SettingsActivity::class.java.name,
+        )
+        val settingsId = insertFavorite(
+            db,
+            Favorites.ITEM_TYPE_APPLICATION,
+            "Settings",
+            makeLaunchIntent(settingsComponent),
+        )
+        val oldGalleryDeepShortcutId = insertFavorite(
+            db,
+            Favorites.ITEM_TYPE_DEEP_SHORTCUT,
+            "Gallery deep shortcut",
+            makeLaunchIntent(oldGalleryComponent),
+        )
+        val newGalleryComponent = ComponentName(NEW_GALLERY_PACKAGE, NEW_GALLERY_ACTIVITY)
+        val newGalleryIntent = makeLaunchIntent(newGalleryComponent)
+
+        assertEquals(
+            2,
+            GosLauncherDbMigrations.migrateGalleryFavorite(db, newGalleryIntent),
+        )
+        assertEquals(4, getFavoriteDataCount(db))
+        assertFavorite(
+            db,
+            oldGalleryComponentId,
+            Favorites.ITEM_TYPE_APPLICATION,
+            newGalleryComponent,
+        )
+        assertFavorite(
+            db,
+            oldGalleryPackageId,
+            Favorites.ITEM_TYPE_APPLICATION,
+            newGalleryComponent,
+        )
+        assertFavorite(db, settingsId, Favorites.ITEM_TYPE_APPLICATION, settingsComponent)
+        assertFavorite(
+            db,
+            oldGalleryDeepShortcutId,
+            Favorites.ITEM_TYPE_DEEP_SHORTCUT,
+            oldGalleryComponent,
+        )
+    }
+
+    @Test
+    fun runIdempotentMigrations_recordsMigrationVersion() {
+        val db = TestDatabaseHelper(context).writableDatabase
+        GosLauncherDbMigrations.clearIdempotentMigrationVersionForTest(context, db)
+
+        try {
+            val oldGalleryComponent = ComponentName(OLD_GALLERY_PACKAGE, OLD_GALLERY_ACTIVITY)
+            val firstOldGalleryId = insertFavorite(
+                db,
+                Favorites.ITEM_TYPE_APPLICATION,
+                "Gallery",
+                makeLaunchIntent(oldGalleryComponent),
+            )
+            val newGalleryComponent = ComponentName(NEW_GALLERY_PACKAGE, NEW_GALLERY_ACTIVITY)
+            val newGalleryIntent = makeLaunchIntent(newGalleryComponent)
+
+            assertEquals(
+                1,
+                GosLauncherDbMigrations.runIdempotentMigrationsForTest(
+                    context,
+                    db,
+                    newGalleryIntent,
+                ),
+            )
+            assertFavorite(
+                db,
+                firstOldGalleryId,
+                Favorites.ITEM_TYPE_APPLICATION,
+                newGalleryComponent,
+            )
+
+            val secondOldGalleryId = insertFavorite(
+                db,
+                Favorites.ITEM_TYPE_APPLICATION,
+                "Gallery",
+                makeLaunchIntent(oldGalleryComponent),
+            )
+
+            assertEquals(
+                0,
+                GosLauncherDbMigrations.runIdempotentMigrationsForTest(
+                    context,
+                    db,
+                    newGalleryIntent,
+                ),
+            )
+            assertFavorite(
+                db,
+                secondOldGalleryId,
+                Favorites.ITEM_TYPE_APPLICATION,
+                oldGalleryComponent,
+            )
+        } finally {
+            GosLauncherDbMigrations.clearIdempotentMigrationVersionForTest(context, db)
+        }
+    }
+
+    private fun insertFavorite(
+        db: SQLiteDatabase,
+        itemType: Int,
+        title: String,
+        intent: Intent,
+    ): Long {
+        val values = ContentValues().apply {
+            put(Favorites.ITEM_TYPE, itemType)
+            put(Favorites.TITLE, title)
+            put(Favorites.INTENT, intent.toUri(0))
+            put(Favorites.CONTAINER, Favorites.CONTAINER_HOTSEAT)
+            put(Favorites.SCREEN, SCREEN)
+            put(Favorites.CELLX, CELL_X)
+            put(Favorites.CELLY, CELL_Y)
+            put(Favorites.SPANX, SPAN_X)
+            put(Favorites.SPANY, SPAN_Y)
+        }
+        return db.insert(Favorites.TABLE_NAME, null, values)
+    }
+
+    private fun makeLaunchIntent(component: ComponentName): Intent {
+        return Intent(Intent.ACTION_MAIN)
+            .addCategory(Intent.CATEGORY_LAUNCHER)
+            .setComponent(component)
+            .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
+    }
+
+    private fun makePackageIntent(packageName: String): Intent {
+        return Intent(Intent.ACTION_MAIN)
+            .addCategory(Intent.CATEGORY_APP_GALLERY)
+            .setPackage(packageName)
+    }
+
+    private fun getFavoriteDataCount(db: SQLiteDatabase): Int {
+        val count = db.query(
+            Favorites.TABLE_NAME,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+        ).use { cursor ->
+            cursor.count
+        }
+        return count
+    }
+
+    private fun assertFavorite(
+        db: SQLiteDatabase,
+        id: Long,
+        expectedItemType: Int,
+        expectedComponent: ComponentName,
+    ) {
+        db.query(
+            Favorites.TABLE_NAME,
+            arrayOf(
+                Favorites.ITEM_TYPE,
+                Favorites.INTENT,
+                Favorites.CONTAINER,
+                Favorites.SCREEN,
+                Favorites.CELLX,
+                Favorites.CELLY,
+                Favorites.SPANX,
+                Favorites.SPANY,
+            ),
+            "${Favorites._ID} = ?",
+            arrayOf(id.toString()),
+            null,
+            null,
+            null,
+        ).use { cursor ->
+            assertEquals(1, cursor.count)
+            cursor.moveToNext()
+
+            val intent = Intent.parseUri(
+                cursor.getString(cursor.getColumnIndexOrThrow(Favorites.INTENT)),
+                0,
+            )
+            assertEquals(expectedItemType, cursor.getInt(
+                cursor.getColumnIndexOrThrow(Favorites.ITEM_TYPE),
+            ))
+            assertEquals(expectedComponent, intent.component)
+            assertEquals(Favorites.CONTAINER_HOTSEAT, cursor.getInt(
+                cursor.getColumnIndexOrThrow(Favorites.CONTAINER),
+            ))
+            assertEquals(SCREEN, cursor.getInt(cursor.getColumnIndexOrThrow(Favorites.SCREEN)))
+            assertEquals(CELL_X, cursor.getInt(cursor.getColumnIndexOrThrow(Favorites.CELLX)))
+            assertEquals(CELL_Y, cursor.getInt(cursor.getColumnIndexOrThrow(Favorites.CELLY)))
+            assertEquals(SPAN_X, cursor.getInt(cursor.getColumnIndexOrThrow(Favorites.SPANX)))
+            assertEquals(SPAN_Y, cursor.getInt(cursor.getColumnIndexOrThrow(Favorites.SPANY)))
+        }
+    }
+
+    private class TestDatabaseHelper(context: Context) :
+        DatabaseHelper(context, null, Runnable {}) {
+
+        override fun handleOneTimeDataUpgrade(db: SQLiteDatabase) {
+        }
+    }
+
+    private companion object {
+        const val OLD_GALLERY_PACKAGE = "com.android.gallery3d"
+        const val OLD_GALLERY_ACTIVITY = "com.android.gallery3d.app.GalleryActivity"
+        const val NEW_GALLERY_PACKAGE = "app.grapheneos.gallery"
+        const val NEW_GALLERY_ACTIVITY = "com.dot.gallery.Launcher_ReFra"
+        const val SCREEN = 2
+        const val CELL_X = 2
+        const val CELL_Y = 0
+        const val SPAN_X = 1
+        const val SPAN_Y = 1
+    }
+}


### PR DESCRIPTION
Test: `atest Launcher3QuickStepTests --test-filter com.android.launcher3.provider.GrapheneOsLauncherDbMigrationsTest#migrateGalleryFavorite_updatesOnlyOldGalleryApplications` (included in test mapping)