### PR TITLE
fix 3rd-party launcher 3-button recents issues due to RecentsActivity being recreated

### DIFF
--- a/quickstep/src/com/android/quickstep/AbsSwipeUpHandler.java
+++ b/quickstep/src/com/android/quickstep/AbsSwipeUpHandler.java
@@ -1128,17 +1128,7 @@ public abstract class AbsSwipeUpHandler<
     @Override
     public void onRecentsAnimationCanceled(HashMap<Integer, ThumbnailData> thumbnailDatas) {
         ActiveGestureProtoLogProxy.logAbsSwipeUpHandlerOnRecentsAnimationCanceled();
-        mContextInitListener.unregister("AbsSwipeUpHandler.onRecentsAnimationCanceled");
-        mStateCallback.setStateOnUiThread(STATE_GESTURE_CANCELLED | STATE_HANDLER_INVALIDATED);
-        // Defer clearing the controller and the targets until after we've updated the state
-        mRecentsAnimationController = null;
-        mRecentsAnimationTargets = null;
-        if (mRecentsView != null) {
-            mRecentsView.setRecentsAnimationTargets(null, null);
-        }
-        if (!mGestureState.useSyntheticRecentsTransition()) {
-            maybeHandleUnfinishedTaskLaunch("onRecentsAnimationCanceled");
-        }
+        cleanUpOnFailedRecentsAnimation("AbsSwipeUpHandler.onRecentsAnimationCanceled");
     }
 
     @UiThread
@@ -2419,6 +2409,20 @@ public abstract class AbsSwipeUpHandler<
         mTaskSnapshotCache.clear();
     }
 
+    private void cleanUpOnFailedRecentsAnimation(@NonNull String reason) {
+        mContextInitListener.unregister(reason);
+        mStateCallback.setStateOnUiThread(STATE_GESTURE_CANCELLED | STATE_HANDLER_INVALIDATED);
+        // Defer clearing the controller and the targets until after we've updated the state
+        mRecentsAnimationController = null;
+        mRecentsAnimationTargets = null;
+        if (mRecentsView != null) {
+            mRecentsView.setRecentsAnimationTargets(null, null);
+        }
+        if (!mGestureState.useSyntheticRecentsTransition()) {
+            maybeHandleUnfinishedTaskLaunch(reason);
+        }
+    }
+
     private void invalidateHandler() {
         if (!mContainerInterface.isInLiveTileMode() || mGestureState.getEndTarget() != RECENTS) {
             mInputConsumerProxy.destroy();
@@ -2819,6 +2823,12 @@ public abstract class AbsSwipeUpHandler<
         if (mRecentsView != null) {
             mRecentsView.setRecentsAnimationTargets(null, null);
         }
+    }
+
+    @Override
+    public void onRecentsAnimationStartTimedOut() {
+        ActiveGestureProtoLogProxy.logAbsSwipeUpHandlerOnRecentsAnimationStartTimedOut();
+        cleanUpOnFailedRecentsAnimation("AbsSwipeUpHandler.onRecentsAnimationStartTimedOut");
     }
 
     private boolean hasStartedTaskBefore(@NonNull RemoteAnimationTarget[] appearedTaskTargets) {

--- a/quickstep/src/com/android/quickstep/AbsSwipeUpHandler.java
+++ b/quickstep/src/com/android/quickstep/AbsSwipeUpHandler.java
@@ -224,6 +224,8 @@ public abstract class AbsSwipeUpHandler<
     protected @Nullable RECENTS_VIEW mRecentsView;
     protected Runnable mGestureEndCallback;
     protected Runnable mGestureAnimationEndCallback;
+    // Keep the existing Runnable callback API stable and expose the completion reason separately.
+    private GestureAnimationEndResult mGestureAnimationEndResult = GestureAnimationEndResult.NORMAL;
     protected MultiStateCallback mStateCallback;
     protected boolean mCanceled;
     private boolean mRecentsViewScrollLinked = false;
@@ -2434,6 +2436,7 @@ public abstract class AbsSwipeUpHandler<
         if (mGestureEndCallback != null) {
             mGestureEndCallback.run();
         }
+        finishGestureAnimationIfLauncherIsGone();
 
         mContextInitListener.unregister("AbsSwipeUpHandler.invalidateHandler");
         TaskStackChangeListeners.getInstance().unregisterTaskStackListener(
@@ -2452,10 +2455,32 @@ public abstract class AbsSwipeUpHandler<
         if (mRecentsView != null) {
             mRecentsView.onGestureAnimationEnd();
         }
-        if (mGestureAnimationEndCallback != null) {
-            mGestureAnimationEndCallback.run();
-        }
+        runGestureAnimationEndCallback(GestureAnimationEndResult.NORMAL);
         resetLauncherListeners();
+    }
+
+    private void finishGestureAnimationIfLauncherIsGone() {
+        if (mStateCallback.hasStates(STATE_LAUNCHER_PRESENT)) {
+            return;
+        }
+        if (mGestureAnimationEndCallback == null) {
+            return;
+        }
+        // A pending recents animation can still finish back to the previous app after Launcher is
+        // destroyed. Wait for TaskAnimationManager to force-finish it before retrying the command.
+        Log.w(TAG, "Recovering overview command after Launcher was destroyed during recents");
+        ActiveGestureProtoLogProxy.logOverviewCommandRecoveredAfterLauncherGone();
+        mTaskAnimationManager.onLauncherDestroyed(
+                () -> runGestureAnimationEndCallback(GestureAnimationEndResult.LAUNCHER_DESTROYED));
+    }
+
+    private void runGestureAnimationEndCallback(GestureAnimationEndResult result) {
+        mGestureAnimationEndResult = result;
+        Runnable callback = mGestureAnimationEndCallback;
+        mGestureAnimationEndCallback = null;
+        if (callback != null) {
+            callback.run();
+        }
     }
 
     private void endLauncherTransitionController() {
@@ -2677,6 +2702,15 @@ public abstract class AbsSwipeUpHandler<
 
     public void setGestureAnimationEndCallback(Runnable gestureAnimationEndCallback) {
         mGestureAnimationEndCallback = gestureAnimationEndCallback;
+    }
+
+    public GestureAnimationEndResult getGestureAnimationEndResult() {
+        return mGestureAnimationEndResult;
+    }
+
+    public enum GestureAnimationEndResult {
+        NORMAL,
+        LAUNCHER_DESTROYED,
     }
 
     protected void linkRecentsViewScroll() {

--- a/quickstep/src/com/android/quickstep/GestureState.java
+++ b/quickstep/src/com/android/quickstep/GestureState.java
@@ -188,6 +188,9 @@ public class GestureState implements RecentsAnimationCallbacks.RecentsAnimationL
     private CachedTaskInfo mRunningTask;
     private GestureEndTarget mEndTarget;
     private RemoteAnimationTarget[] mLastAppearedTaskTargets;
+    // Task ids used for RecentsView lookup. These can differ from the Shell target task ids when
+    // legacy tracking reports a child home task while Shell animates the root home task.
+    private int[] mLastAppearedTaskIds;
     private Set<Integer> mPreviouslyAppearedTaskIds = new HashSet<>();
     private int[] mLastStartedTaskId = new int[]{INVALID_TASK_ID, INVALID_TASK_ID};
     private HashMap<Integer, ThumbnailData> mRecentsAnimationCanceledSnapshots;
@@ -218,6 +221,7 @@ public class GestureState implements RecentsAnimationCallbacks.RecentsAnimationL
         mRunningTask = other.mRunningTask;
         mEndTarget = other.mEndTarget;
         mLastAppearedTaskTargets = other.mLastAppearedTaskTargets;
+        mLastAppearedTaskIds = other.mLastAppearedTaskIds;
         mPreviouslyAppearedTaskIds = other.mPreviouslyAppearedTaskIds;
         mLastStartedTaskId = other.mLastStartedTaskId;
     }
@@ -390,12 +394,27 @@ public class GestureState implements RecentsAnimationCallbacks.RecentsAnimationL
      * Updates the last task that appeared during this gesture.
      */
     public void updateLastAppearedTaskTargets(RemoteAnimationTarget[] lastAppearedTaskTargets) {
+        updateLastAppearedTaskTargets(lastAppearedTaskTargets,
+                getTaskIds(lastAppearedTaskTargets));
+    }
+
+    /**
+     * Updates the last task that appeared during this gesture.
+     */
+    public void updateLastAppearedTaskTargets(RemoteAnimationTarget[] lastAppearedTaskTargets,
+            int[] lastAppearedTaskIds) {
         mLastAppearedTaskTargets = lastAppearedTaskTargets;
-        for (RemoteAnimationTarget target : lastAppearedTaskTargets) {
-            if (target == null) {
+        mLastAppearedTaskIds = lastAppearedTaskIds == null
+                ? null
+                : Arrays.copyOf(lastAppearedTaskIds, lastAppearedTaskIds.length);
+        if (mLastAppearedTaskIds == null) {
+            return;
+        }
+        for (int taskId : mLastAppearedTaskIds) {
+            if (taskId == INVALID_TASK_ID) {
                 continue;
             }
-            mPreviouslyAppearedTaskIds.add(target.taskId);
+            mPreviouslyAppearedTaskIds.add(taskId);
         }
     }
 
@@ -403,12 +422,19 @@ public class GestureState implements RecentsAnimationCallbacks.RecentsAnimationL
      * @return The id of the task that appeared during this gesture.
      */
     public int[] getLastAppearedTaskIds() {
-        if (mLastAppearedTaskTargets == null) {
+        if (mLastAppearedTaskIds == null) {
             return new int[]{INVALID_TASK_ID, INVALID_TASK_ID};
         } else {
-            return Arrays.stream(mLastAppearedTaskTargets)
-                    .mapToInt(target -> target != null ? target.taskId : INVALID_TASK_ID).toArray();
+            return Arrays.copyOf(mLastAppearedTaskIds, mLastAppearedTaskIds.length);
         }
+    }
+
+    private int[] getTaskIds(@Nullable RemoteAnimationTarget[] lastAppearedTaskTargets) {
+        if (lastAppearedTaskTargets == null) {
+            return null;
+        }
+        return Arrays.stream(lastAppearedTaskTargets)
+                .mapToInt(target -> target != null ? target.taskId : INVALID_TASK_ID).toArray();
     }
 
     public void updatePreviouslyAppearedTaskIds(Set<Integer> previouslyAppearedTaskIds) {
@@ -596,6 +622,7 @@ public class GestureState implements RecentsAnimationCallbacks.RecentsAnimationL
         pw.println(prefix + "\tendTarget=" + mEndTarget);
         pw.println(prefix + "\tlastAppearedTaskTargetId="
                 + Arrays.toString(mLastAppearedTaskTargets));
+        pw.println(prefix + "\tlastAppearedTaskIds=" + Arrays.toString(mLastAppearedTaskIds));
         pw.println(prefix + "\tlastStartedTaskId=" + Arrays.toString(mLastStartedTaskId));
         pw.println(prefix + "\tisRecentsAnimationRunning=" + isRecentsAnimationRunning());
     }

--- a/quickstep/src/com/android/quickstep/OverviewCommandHelper.kt
+++ b/quickstep/src/com/android/quickstep/OverviewCommandHelper.kt
@@ -45,6 +45,7 @@ import com.android.launcher3.util.OverviewCommandHelperProtoLogProxy
 import com.android.launcher3.util.OverviewReleaseFlags.enableGridOnlyOverview
 import com.android.launcher3.util.RunnableList
 import com.android.launcher3.util.coroutines.DispatcherProvider
+import com.android.quickstep.AbsSwipeUpHandler.GestureAnimationEndResult
 import com.android.quickstep.GestureState.GestureEndTarget
 import com.android.quickstep.GestureState.displaySupportsHomeGesture
 import com.android.quickstep.OverviewCommandHelper.CommandInfo.CommandStatus
@@ -71,6 +72,7 @@ import dagger.assisted.AssistedInject
 import java.io.PrintWriter
 import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.TimeUnit
+import kotlin.coroutines.coroutineContext
 import kotlin.coroutines.resume
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -206,9 +208,18 @@ constructor(
             coroutineScope.launch(dispatcherProvider.main) {
                 traceSection("OverviewCommandHelper.executeCommandWithTimeout") {
                     withTimeout(QUEUE_WAIT_DURATION_IN_MS) {
-                        executeCommandSuspended(command)
+                        val result = executeCommandWithLauncherDestroyedRetry(command)
                         ensureActive()
-                        onCommandFinished(command)
+                        if (result == CommandExecutionResult.COMPLETED) {
+                            onCommandFinished(command)
+                        } else {
+                            Log.w(
+                                TAG,
+                                "Canceling overview command after repeated Launcher destruction " +
+                                    "during recents",
+                            )
+                            cancelCommand(command, throwable = null)
+                        }
                     }
                 }
             }
@@ -233,21 +244,69 @@ constructor(
      * Executes the task and returns true if next task can be executed. If false, then the next task
      * is deferred until [.scheduleNextTask] is called
      */
-    private suspend fun executeCommandSuspended(command: CommandInfo) =
+    private suspend fun executeCommandWithLauncherDestroyedRetry(
+        command: CommandInfo
+    ): CommandExecutionResult {
+        var result = executeCommandSuspended(command)
+        coroutineContext.ensureActive()
+        if (result != CommandExecutionResult.RETRY_AFTER_LAUNCHER_DESTROYED) {
+            return result
+        }
+
+        // Launcher can be relaunched after the command starts but before Shell finishes the old
+        // recents animation. Retry once after that forced finish so the user action is not consumed
+        // by the stale animation.
+        Log.w(TAG, "Retrying overview command after Launcher was destroyed during recents")
+        result = executeCommandSuspended(command)
+        coroutineContext.ensureActive()
+        return result
+    }
+
+    /**
+     * Executes the task and returns true if next task can be executed. If false, then the next task
+     * is deferred until [.scheduleNextTask] is called
+     */
+    private suspend fun executeCommandSuspended(command: CommandInfo): CommandExecutionResult =
         suspendCancellableCoroutine { continuation ->
+            var hasResult = false
+
+            fun resumeWith(result: CommandExecutionResult) {
+                if (hasResult || !continuation.isActive) {
+                    return
+                }
+                hasResult = true
+                continuation.resume(result)
+            }
+
+            fun processCallbackResult(result: CommandExecutionResult) {
+                OverviewCommandHelperProtoLogProxy.logExecutedCommandWithResult(
+                    command,
+                    result == CommandExecutionResult.COMPLETED,
+                )
+                resumeWith(result)
+            }
+
             fun processResult(isCompleted: Boolean) {
+                if (hasResult) {
+                    return
+                }
                 OverviewCommandHelperProtoLogProxy.logExecutedCommandWithResult(
                     command,
                     isCompleted,
                 )
                 if (isCompleted) {
-                    continuation.resume(Unit)
+                    resumeWith(CommandExecutionResult.COMPLETED)
                 } else {
                     OverviewCommandHelperProtoLogProxy.logWaitingForCommandCallback(command)
                 }
             }
 
-            val result = executeCommand(command, onCallbackResult = { processResult(true) })
+            // Keep command callbacks as no-argument callbacks for rebase portability; recents
+            // transition completion writes the reason before invoking this callback.
+            command.callbackExecutionResult = CommandExecutionResult.COMPLETED
+            val result = executeCommand(command) {
+                processCallbackResult(command.callbackExecutionResult)
+            }
             processResult(result)
 
             continuation.invokeOnCancellation { cancelCommand(command, it) }
@@ -672,6 +731,9 @@ constructor(
         command.removeListener(handler)
         Trace.endAsyncSection(TRANSITION_NAME, 0)
         onRecentsViewFocusUpdated(command)
+        if (handler.gestureAnimationEndResult == GestureAnimationEndResult.LAUNCHER_DESTROYED) {
+            command.callbackExecutionResult = CommandExecutionResult.RETRY_AFTER_LAUNCHER_DESTROYED
+        }
         onCommandResult()
     }
 
@@ -776,6 +838,11 @@ constructor(
         pw.println("  keyboardFocusTask=$keyboardFocusTask")
     }
 
+    enum class CommandExecutionResult {
+        COMPLETED,
+        RETRY_AFTER_LAUNCHER_DESTROYED,
+    }
+
     @VisibleForTesting
     data class CommandInfo(
         val type: CommandType,
@@ -785,6 +852,10 @@ constructor(
         val displayId: Int = DEFAULT_DISPLAY,
         val isLastOfBatch: Boolean = true,
     ) {
+        // Set before invoking a deferred command callback when completion needs a non-default
+        // outcome, such as retrying after Launcher was destroyed during recents.
+        var callbackExecutionResult: CommandExecutionResult = CommandExecutionResult.COMPLETED
+
         fun setAnimationCallbacks(recentsAnimationCallbacks: RecentsAnimationCallbacks) {
             this.animationCallbacks = recentsAnimationCallbacks
         }

--- a/quickstep/src/com/android/quickstep/RecentsAnimationCallbacks.java
+++ b/quickstep/src/com/android/quickstep/RecentsAnimationCallbacks.java
@@ -167,6 +167,15 @@ public class RecentsAnimationCallbacks implements
         });
     }
 
+    public void onRecentsAnimationStartTimedOut() {
+        Utilities.postAsyncCallback(MAIN_EXECUTOR.getHandler(), () -> {
+            ActiveGestureProtoLogProxy.logRecentsAnimationCallbacksOnAnimationStartTimedOut();
+            for (RecentsAnimationListener listener : getListeners()) {
+                listener.onRecentsAnimationStartTimedOut();
+            }
+        });
+    }
+
     private void onAnimationFinished(RecentsAnimationController controller) {
         Utilities.postAsyncCallback(MAIN_EXECUTOR.getHandler(), () -> {
             ActiveGestureProtoLogProxy.logAbsSwipeUpHandlerOnRecentsAnimationFinished();
@@ -217,6 +226,11 @@ public class RecentsAnimationCallbacks implements
          * Callback made whenever the recents animation is finished.
          */
         default void onRecentsAnimationFinished(@NonNull RecentsAnimationController controller) {}
+
+        /**
+         * Callback made when the recents animation start callback times out.
+         */
+        default void onRecentsAnimationStartTimedOut() {}
 
         /**
          * Callback made when a task started from the recents is ready for an app transition.

--- a/quickstep/src/com/android/quickstep/RecentsAnimationTargetResolver.kt
+++ b/quickstep/src/com/android/quickstep/RecentsAnimationTargetResolver.kt
@@ -1,0 +1,100 @@
+package com.android.quickstep
+
+import android.app.ActivityTaskManager.INVALID_TASK_ID
+import android.app.TaskInfo
+import android.app.WindowConfiguration.ACTIVITY_TYPE_HOME
+import android.content.ComponentName
+import android.util.Log
+import android.view.RemoteAnimationTarget
+import com.android.wm.shell.Flags.enableShellTopTaskTracking
+
+object RecentsAnimationTargetResolver {
+    private const val TAG = "RecentsAnimationTargetResolver"
+
+    @JvmStatic
+    fun findTaskForLastAppearedTarget(
+        targets: RecentsAnimationTargets,
+        lastGestureState: GestureState?,
+        taskId: Int,
+    ): LastAppearedTask {
+        findTaskById(targets.apps, taskId)?.let { return LastAppearedTask(it, it.taskId) }
+        findLegacyHomeTarget(targets, lastGestureState, taskId)?.let { return it }
+        val target = targets.findTask(taskId)
+        return LastAppearedTask(target, target?.taskId ?: INVALID_TASK_ID)
+    }
+
+    private fun findLegacyHomeTarget(
+        targets: RecentsAnimationTargets,
+        lastGestureState: GestureState?,
+        taskId: Int,
+    ): LastAppearedTask? {
+        if (enableShellTopTaskTracking() || lastGestureState == null) return null
+
+        val runningTask = lastGestureState.runningTask ?: return null
+        if (!runningTask.isHomeTask() || !runningTask.topGroupedTaskContainsTask(taskId)) {
+            return null
+        }
+
+        val homeTarget =
+            findUniqueMatchingHomeTarget(
+                targets.apps,
+                runningTask.getLegacyBaseTask(),
+                runningTask.packageName,
+            ) ?: return null
+
+        // Legacy task tracking can cache the third-party home task id while Shell animates the
+        // root home task. Keep the Shell target intact and report the cached id separately for
+        // RecentsView lookup.
+        return LastAppearedTask(homeTarget, taskId).also {
+            Log.d(
+                TAG,
+                "onRecentsAnimationStart: using home target taskId=${homeTarget.taskId} " +
+                    "for cachedTaskId=$taskId",
+            )
+        }
+    }
+
+    private fun findTaskById(
+        targets: Array<RemoteAnimationTarget>?,
+        taskId: Int,
+    ): RemoteAnimationTarget? = targets?.firstOrNull { it.taskId == taskId }
+
+    private fun findUniqueMatchingHomeTarget(
+        targets: Array<RemoteAnimationTarget>?,
+        cachedTask: TaskInfo?,
+        packageName: String?,
+    ): RemoteAnimationTarget? {
+        return targets
+            ?.singleOrNull {
+                it.windowConfiguration?.activityType == ACTIVITY_TYPE_HOME &&
+                    it.matchesCachedTask(cachedTask, packageName)
+            }
+    }
+
+    private fun RemoteAnimationTarget.matchesCachedTask(
+        cachedTask: TaskInfo?,
+        packageName: String?,
+    ): Boolean {
+        val targetInfo = taskInfo
+        if (cachedTask != null) {
+            if (targetInfo == null) return false
+            if (cachedTask.userId != targetInfo.userId) return false
+            if (cachedTask.displayId != targetInfo.displayId) return false
+        }
+
+        if (packageName == null) return true
+        if (targetInfo == null) return false
+        if (targetInfo.topActivity.matchesPackage(packageName)) return true
+        if (targetInfo.baseActivity.matchesPackage(packageName)) return true
+        if (targetInfo.realActivity.matchesPackage(packageName)) return true
+        return false
+    }
+
+    private fun ComponentName?.matchesPackage(packageName: String): Boolean =
+        this?.packageName == packageName
+
+    data class LastAppearedTask(
+        val target: RemoteAnimationTarget?,
+        val taskId: Int,
+    )
+}

--- a/quickstep/src/com/android/quickstep/TaskAnimationManager.java
+++ b/quickstep/src/com/android/quickstep/TaskAnimationManager.java
@@ -50,6 +50,7 @@ import com.android.launcher3.dagger.ApplicationContext;
 import com.android.launcher3.taskbar.TaskbarInteractor;
 import com.android.launcher3.util.DaggerSingletonObject;
 import com.android.launcher3.util.DisplayController;
+import com.android.launcher3.util.RunnableList;
 import com.android.quickstep.dagger.QuickstepBaseAppComponent;
 import com.android.quickstep.util.ActiveGestureLog;
 import com.android.quickstep.util.ActiveGestureProtoLogProxy;
@@ -100,6 +101,8 @@ public class TaskAnimationManager implements RecentsAnimationCallbacks.RecentsAn
     private final int mDisplayId;
 
     private boolean mLauncherDestroyCallbackSet = false;
+    private boolean mLauncherDestroyForceFinishPending = false;
+    private RunnableList mLauncherDestroyedCallbacks;
 
     public static final DaggerSingletonObject<PerDisplayRepository<TaskAnimationManager>>
             REPOSITORY_INSTANCE = new DaggerSingletonObject<>(
@@ -640,15 +643,38 @@ public class TaskAnimationManager implements RecentsAnimationCallbacks.RecentsAn
     }
 
     void onLauncherDestroyed() {
-        if (!mRecentsAnimationStartPending) {
-            return;
-        }
-        if (mCallbacks == null) {
-            return;
-        }
+        onLauncherDestroyed(/* onForceFinishComplete= */ null);
+    }
+
+    void onLauncherDestroyed(@Nullable Runnable onForceFinishComplete) {
+        addLauncherDestroyedCallback(onForceFinishComplete);
         if (mLauncherDestroyCallbackSet) {
             return;
         }
+        if (mLauncherDestroyForceFinishPending) {
+            return;
+        }
+        if (mController != null) {
+            // Android 17 Beta 4 CP21.260330.008 NexusLauncher force-finishes here when the start
+            // callback already provided a controller. Preserve that path so the retry hook also
+            // covers this timing.
+            mLauncherDestroyForceFinishPending = true;
+            finishRunningRecentsAnimation(
+                    /* toHome= */ false,
+                    /* forceFinish= */ true,
+                    /* forceFinishCb= */ TaskAnimationManager.this::runLauncherDestroyedCallbacks,
+                    mController,
+                    /* reason= */ new ActiveGestureLog.CompoundString(
+                            "TaskAnimationManager.onLauncherDestroyed"));
+            return;
+        }
+        if (!mRecentsAnimationStartPending || mCallbacks == null) {
+            runLauncherDestroyedCallbacks();
+            return;
+        }
+        // Launcher may be destroyed before Shell sends onRecentsAnimationStart. In that case,
+        // callers waiting to retry the user command must wait until the late start callback has
+        // been force-finished, otherwise Shell can still finish back to the previous app.
         ActiveGestureProtoLogProxy.logQueuingForceFinishRecentsAnimation();
         mLauncherDestroyCallbackSet = true;
         mCallbacks.addListener(new RecentsAnimationCallbacks.RecentsAnimationListener() {
@@ -657,16 +683,37 @@ public class TaskAnimationManager implements RecentsAnimationCallbacks.RecentsAn
                     RecentsAnimationController controller,
                     RecentsAnimationTargets targets,
                     @Nullable TransitionInfo transitionInfo) {
+                mLauncherDestroyForceFinishPending = true;
                 finishRunningRecentsAnimation(
                         /* toHome= */ false,
                         /* forceFinish= */ true,
-                        /* forceFinishCb= */ null,
+                        /* forceFinishCb= */ TaskAnimationManager.this::runLauncherDestroyedCallbacks,
                         controller,
                         /* reason= */ new ActiveGestureLog.CompoundString(
                                 "TaskAnimationManager.onLauncherDestroyed"));
                 mLauncherDestroyCallbackSet = false;
             }
         });
+    }
+
+    private void addLauncherDestroyedCallback(@Nullable Runnable callback) {
+        if (callback == null) {
+            return;
+        }
+        if (mLauncherDestroyedCallbacks == null) {
+            mLauncherDestroyedCallbacks = new RunnableList();
+        }
+        mLauncherDestroyedCallbacks.add(callback);
+    }
+
+    private void runLauncherDestroyedCallbacks() {
+        mLauncherDestroyCallbackSet = false;
+        mLauncherDestroyForceFinishPending = false;
+        RunnableList callbacks = mLauncherDestroyedCallbacks;
+        mLauncherDestroyedCallbacks = null;
+        if (callbacks != null) {
+            callbacks.executeAllAndDestroy();
+        }
     }
 
     /**
@@ -678,6 +725,10 @@ public class TaskAnimationManager implements RecentsAnimationCallbacks.RecentsAn
             return;
         }
         ActiveGestureProtoLogProxy.logCleanUpRecentsAnimation();
+        // If the animation is canceled before the late start callback arrives, there is no Shell
+        // controller left to force-finish. Let the waiting command retry immediately.
+        boolean runLauncherDestroyedCallbacks =
+                mLauncherDestroyCallbackSet && !mLauncherDestroyForceFinishPending;
         if (mLiveTileCleanUpHandler != null) {
             mLiveTileCleanUpHandler.run();
             mLiveTileCleanUpHandler = null;
@@ -702,6 +753,9 @@ public class TaskAnimationManager implements RecentsAnimationCallbacks.RecentsAn
         mLastGestureState = null;
         mLastAppearedTaskTargets = null;
         mLastAppearedTaskIds = null;
+        if (runLauncherDestroyedCallbacks) {
+            runLauncherDestroyedCallbacks();
+        }
     }
 
     @Nullable

--- a/quickstep/src/com/android/quickstep/TaskAnimationManager.java
+++ b/quickstep/src/com/android/quickstep/TaskAnimationManager.java
@@ -275,7 +275,7 @@ public class TaskAnimationManager implements RecentsAnimationCallbacks.RecentsAn
             Log.wtf(TAG, "Recents animation start has been pending for over "
                     + RECENTS_ANIMATION_START_TIMEOUT_MS + "ms");
             ActiveGestureProtoLogProxy.logRecentsAnimationStartTimedOut();
-            cleanUpRecentsAnimation(newCallbacks);
+            newCallbacks.onRecentsAnimationStartTimedOut();
         };
         mCallbacks.addListener(new RecentsAnimationCallbacks.RecentsAnimationListener() {
             @Override
@@ -351,6 +351,11 @@ public class TaskAnimationManager implements RecentsAnimationCallbacks.RecentsAn
                     MAIN_EXECUTOR.getHandler().removeCallbacks(
                             recentsAnimationStartTimeoutCallback);
                 }
+                cleanUpRecentsAnimation(newCallbacks);
+            }
+
+            @Override
+            public void onRecentsAnimationStartTimedOut() {
                 cleanUpRecentsAnimation(newCallbacks);
             }
 

--- a/quickstep/src/com/android/quickstep/TaskAnimationManager.java
+++ b/quickstep/src/com/android/quickstep/TaskAnimationManager.java
@@ -15,6 +15,7 @@
  */
 package com.android.quickstep;
 
+import static android.app.ActivityTaskManager.INVALID_TASK_ID;
 import static android.app.WindowConfiguration.ACTIVITY_TYPE_HOME;
 import static android.view.Display.DEFAULT_DISPLAY;
 
@@ -67,6 +68,7 @@ import dagger.assisted.AssistedInject;
 
 import java.io.PrintWriter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -90,6 +92,7 @@ public class TaskAnimationManager implements RecentsAnimationCallbacks.RecentsAn
     // Temporary until we can hook into gesture state events
     private GestureState mLastGestureState;
     private RemoteAnimationTarget[] mLastAppearedTaskTargets;
+    private int[] mLastAppearedTaskIds;
     private Runnable mLiveTileCleanUpHandler;
 
     private boolean mRecentsAnimationStartPending = false;
@@ -301,11 +304,16 @@ public class TaskAnimationManager implements RecentsAnimationCallbacks.RecentsAn
                 //  to all appeared targets directly vs just looking at running ones
                 int[] runningTaskIds = mLastGestureState.getRunningTaskIds(targets.apps.length > 1);
                 mLastAppearedTaskTargets = new RemoteAnimationTarget[runningTaskIds.length];
+                mLastAppearedTaskIds = new int[runningTaskIds.length];
                 for (int i = 0; i < runningTaskIds.length; i++) {
-                    RemoteAnimationTarget task = mTargets.findTask(runningTaskIds[i]);
-                    mLastAppearedTaskTargets[i] = task;
+                    RecentsAnimationTargetResolver.LastAppearedTask task =
+                            RecentsAnimationTargetResolver.findTaskForLastAppearedTarget(
+                                    mTargets, mLastGestureState, runningTaskIds[i]);
+                    mLastAppearedTaskTargets[i] = task.getTarget();
+                    mLastAppearedTaskIds[i] = task.getTaskId();
                 }
-                mLastGestureState.updateLastAppearedTaskTargets(mLastAppearedTaskTargets);
+                mLastGestureState.updateLastAppearedTaskTargets(mLastAppearedTaskTargets,
+                        mLastAppearedTaskIds);
 
                 if (mTargets.hasRecents
                         // The filtered (MODE_CLOSING) targets only contain 1 home activity.
@@ -418,7 +426,9 @@ public class TaskAnimationManager implements RecentsAnimationCallbacks.RecentsAn
                 }
                 if (mController != null) {
                     mLastAppearedTaskTargets = appearedTaskTargets;
-                    mLastGestureState.updateLastAppearedTaskTargets(mLastAppearedTaskTargets);
+                    mLastAppearedTaskIds = getTaskIds(appearedTaskTargets);
+                    mLastGestureState.updateLastAppearedTaskTargets(mLastAppearedTaskTargets,
+                            mLastAppearedTaskIds);
                 }
             }
         });
@@ -484,7 +494,7 @@ public class TaskAnimationManager implements RecentsAnimationCallbacks.RecentsAn
         mCallbacks.addListener(gestureState);
         gestureState.setState(STATE_RECENTS_ANIMATION_INITIALIZED
                 | STATE_RECENTS_ANIMATION_STARTED);
-        gestureState.updateLastAppearedTaskTargets(mLastAppearedTaskTargets);
+        gestureState.updateLastAppearedTaskTargets(mLastAppearedTaskTargets, mLastAppearedTaskIds);
         return mCallbacks;
     }
 
@@ -620,6 +630,15 @@ public class TaskAnimationManager implements RecentsAnimationCallbacks.RecentsAn
         return mController != null;
     }
 
+    private static int[] getTaskIds(@Nullable RemoteAnimationTarget[] targets) {
+        if (targets == null) {
+            return null;
+        }
+        return Arrays.stream(targets)
+                .mapToInt(target -> target != null ? target.taskId : INVALID_TASK_ID)
+                .toArray();
+    }
+
     void onLauncherDestroyed() {
         if (!mRecentsAnimationStartPending) {
             return;
@@ -682,6 +701,7 @@ public class TaskAnimationManager implements RecentsAnimationCallbacks.RecentsAn
         mTransitionInfo = null;
         mLastGestureState = null;
         mLastAppearedTaskTargets = null;
+        mLastAppearedTaskIds = null;
     }
 
     @Nullable

--- a/quickstep/src_protolog/com/android/quickstep/util/ActiveGestureProtoLogProxy.java
+++ b/quickstep/src_protolog/com/android/quickstep/util/ActiveGestureProtoLogProxy.java
@@ -83,6 +83,13 @@ public class ActiveGestureProtoLogProxy {
         }
     }
 
+    public static void logAbsSwipeUpHandlerOnRecentsAnimationStartTimedOut() {
+        ActiveGestureLog.INSTANCE.addLog("AbsSwipeUpHandler.onRecentsAnimationStartTimedOut");
+        if (willProtoLog()) {
+            ProtoLog.d(PROTO_LOG_GROUP, "AbsSwipeUpHandler.onRecentsAnimationStartTimedOut");
+        }
+    }
+
     public static void logAbsSwipeUpHandlerOnRecentsAnimationFinished() {
         ActiveGestureLog.INSTANCE.addLog(
                 /* event= */ "RecentsAnimationCallbacks.onAnimationFinished",
@@ -122,6 +129,15 @@ public class ActiveGestureProtoLogProxy {
                 /* gestureEvent= */ ON_CANCEL_RECENTS_ANIMATION);
         if (willProtoLog()) {
             ProtoLog.d(PROTO_LOG_GROUP, "RecentsAnimationCallbacks.onAnimationCanceled");
+        }
+    }
+
+    public static void logRecentsAnimationCallbacksOnAnimationStartTimedOut() {
+        ActiveGestureLog.INSTANCE.addLog(
+                "RecentsAnimationCallbacks.onRecentsAnimationStartTimedOut");
+        if (willProtoLog()) {
+            ProtoLog.d(PROTO_LOG_GROUP,
+                    "RecentsAnimationCallbacks.onRecentsAnimationStartTimedOut");
         }
     }
 

--- a/quickstep/src_protolog/com/android/quickstep/util/ActiveGestureProtoLogProxy.java
+++ b/quickstep/src_protolog/com/android/quickstep/util/ActiveGestureProtoLogProxy.java
@@ -83,6 +83,15 @@ public class ActiveGestureProtoLogProxy {
         }
     }
 
+    public static void logOverviewCommandRecoveredAfterLauncherGone() {
+        ActiveGestureLog.INSTANCE.addLog("Recovered stuck overview command after Launcher was "
+                + "gone; this indicates a launcher relaunch race");
+        if (willProtoLog()) {
+            ProtoLog.d(PROTO_LOG_GROUP, "Recovered stuck overview command after Launcher was "
+                    + "gone; this indicates a launcher relaunch race");
+        }
+    }
+
     public static void logAbsSwipeUpHandlerOnRecentsAnimationStartTimedOut() {
         ActiveGestureLog.INSTANCE.addLog("AbsSwipeUpHandler.onRecentsAnimationStartTimedOut");
         if (willProtoLog()) {

--- a/quickstep/tests/multivalentTests/src/com/android/quickstep/AbsSwipeUpHandlerTestCase.java
+++ b/quickstep/tests/multivalentTests/src/com/android/quickstep/AbsSwipeUpHandlerTestCase.java
@@ -517,6 +517,18 @@ public abstract class AbsSwipeUpHandlerTestCase<
     }
 
     @Test
+    public void recentsAnimationStartTimeout_invalidatesSwipeHandler() {
+        SWIPE_HANDLER handler = createSwipeHandler();
+
+        runOnMainSync(handler::onRecentsAnimationStartTimedOut);
+
+        verify(mContextInitListener)
+                .unregister(eq("AbsSwipeUpHandler.onRecentsAnimationStartTimedOut"));
+        assertTrue(handler.mStateCallback.hasStates(STATE_GESTURE_CANCELLED));
+        assertTrue(handler.mStateCallback.hasStates(STATE_HANDLER_INVALIDATED));
+    }
+
+    @Test
     @EnableFlags(com.android.launcher3.Flags.FLAG_MSDL_FEEDBACK)
     public void onMotionPauseDetected_playsSwipeThresholdToken() {
         SWIPE_HANDLER handler = createSwipeHandler();

--- a/quickstep/tests/multivalentTests/src/com/android/quickstep/AbsSwipeUpHandlerTestCase.java
+++ b/quickstep/tests/multivalentTests/src/com/android/quickstep/AbsSwipeUpHandlerTestCase.java
@@ -23,6 +23,8 @@ import static com.android.launcher3.statehandlers.DesktopVisibilityController.IN
 import static com.android.quickstep.AbsSwipeUpHandler.STATE_GESTURE_CANCELLED;
 import static com.android.quickstep.AbsSwipeUpHandler.STATE_HANDLER_INVALIDATED;
 import static com.android.quickstep.AbsSwipeUpHandler.STATE_LAUNCHER_PRESENT;
+import static com.android.quickstep.AbsSwipeUpHandler.GestureAnimationEndResult.LAUNCHER_DESTROYED;
+import static com.android.quickstep.AbsSwipeUpHandler.GestureAnimationEndResult.NORMAL;
 import static com.android.wm.shell.shared.ShellSharedConstants.KEY_EXTRA_SHELL_CAN_HAND_OFF_ANIMATION;
 import static com.android.wm.shell.shared.split.SplitBounds.KEY_EXTRA_SPLIT_BOUNDS;
 import static com.android.wm.shell.shared.split.SplitScreenConstants.SNAP_TO_2_50_50;
@@ -40,6 +42,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -513,7 +516,33 @@ public abstract class AbsSwipeUpHandlerTestCase<
 
         handler.mStateCallback.setState(STATE_HANDLER_INVALIDATED | STATE_LAUNCHER_PRESENT);
 
-        verify(onGestureAnimationEndCallback).run();
+        verify(onGestureAnimationEndCallback, times(1)).run();
+        assertEquals(NORMAL, handler.getGestureAnimationEndResult());
+    }
+
+    @Test
+    public void launcherDestroyedDuringRecentsCommand_waitsForAnimationFinish() {
+        SWIPE_HANDLER handler = createSwipeHandler();
+        Runnable onGestureAnimationEndCallback = mock(Runnable.class);
+        ArgumentCaptor<Runnable> forceFinishCallbackCaptor =
+                ArgumentCaptor.forClass(Runnable.class);
+        handler.setGestureAnimationEndCallback(onGestureAnimationEndCallback);
+        doNothing().when(mTaskAnimationManager).onLauncherDestroyed(any(Runnable.class));
+
+        // Launcher was destroyed before the gesture ended, so the command callback must wait for
+        // TaskAnimationManager to force finish Shell's recents animation.
+        handler.mStateCallback.setState(STATE_HANDLER_INVALIDATED);
+
+        verify(mTaskAnimationManager).onLauncherDestroyed(forceFinishCallbackCaptor.capture());
+        verify(onGestureAnimationEndCallback, never()).run();
+
+        forceFinishCallbackCaptor.getValue().run();
+        verify(onGestureAnimationEndCallback, times(1)).run();
+        assertEquals(LAUNCHER_DESTROYED, handler.getGestureAnimationEndResult());
+
+        handler.mStateCallback.setState(STATE_LAUNCHER_PRESENT);
+
+        verify(onGestureAnimationEndCallback, times(1)).run();
     }
 
     @Test

--- a/quickstep/tests/multivalentTests/src/com/android/quickstep/OverviewCommandHelperTest.kt
+++ b/quickstep/tests/multivalentTests/src/com/android/quickstep/OverviewCommandHelperTest.kt
@@ -34,6 +34,7 @@ import com.android.launcher3.uioverrides.QuickstepLauncher
 import com.android.launcher3.util.LauncherMultivalentJUnit
 import com.android.launcher3.util.RunnableList
 import com.android.launcher3.util.TestDispatcherProvider
+import com.android.quickstep.AbsSwipeUpHandler.GestureAnimationEndResult
 import com.android.quickstep.OverviewCommandHelper.CommandInfo
 import com.android.quickstep.OverviewCommandHelper.CommandInfo.CommandStatus
 import com.android.quickstep.OverviewCommandHelper.CommandType
@@ -60,6 +61,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.anyInt
 import org.mockito.Mockito.spy
+import org.mockito.Mockito.times
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
@@ -147,6 +149,7 @@ class OverviewCommandHelperTest {
 
     private fun mockExecuteCommand() {
         doAnswer { invocation ->
+                @Suppress("UNCHECKED_CAST")
                 val pendingCallback = invocation.arguments[1] as () -> Unit
 
                 val delayInMillis = pendingCallbacksWithDelays.removeFirstOrNull()
@@ -163,7 +166,7 @@ class OverviewCommandHelperTest {
                 delayInMillis == null // if no callback to execute, returns success
             }
             .`when`(sut)
-            .executeCommand(any<CommandInfo>(), any())
+            .executeCommand(any<CommandInfo>(), any<() -> Unit>())
     }
 
     @Test
@@ -529,10 +532,11 @@ class OverviewCommandHelperTest {
             verify(newGestureState)
                 .setHandlingAtomicEvent(GestureState.GestureEndTarget.REJECT_HOME)
 
-            // Make sure we can transition to completed state once we see an end callback.
             val gestureAnimationEndCallbackCaptor = argumentCaptor<Runnable>()
             verify(swipeUpHandler)
                 .setGestureAnimationEndCallback(gestureAnimationEndCallbackCaptor.capture())
+            whenever(swipeUpHandler.gestureAnimationEndResult)
+                .thenReturn(GestureAnimationEndResult.NORMAL)
             gestureAnimationEndCallbackCaptor.firstValue.run()
             runCurrent()
             assertThat(command.status).isEqualTo(CommandStatus.COMPLETED)
@@ -648,17 +652,87 @@ class OverviewCommandHelperTest {
             verify(newGestureState).setHandlingAtomicEvent(GestureState.GestureEndTarget.RECENTS)
             verify(recentView).setKeyboardFocusTask(KeyboardFocusTask.ExpectedCurrentTask)
 
-            // Make sure we can transition to completed state once we see an end callback.
             val gestureAnimationEndCallbackCaptor = argumentCaptor<Runnable>()
             verify(swipeUpHandler)
                 .setGestureAnimationEndCallback(gestureAnimationEndCallbackCaptor.capture())
             whenever(containerInterface.getVisibleRecentsView<RecentsView<*, *>>())
                 .thenReturn(recentView)
+            whenever(swipeUpHandler.gestureAnimationEndResult)
+                .thenReturn(GestureAnimationEndResult.NORMAL)
             gestureAnimationEndCallbackCaptor.firstValue.run()
 
             runCurrent()
             assertThat(command.status).isEqualTo(CommandStatus.COMPLETED)
             verify(recentView).setKeyboardFocusTask(KeyboardFocusTask.Unfocused)
+        }
+
+    @Test
+    fun showWithFocusCommand_retriesAfterLauncherDestroyedDuringRecents() =
+        testScope.runTest {
+            whenever(containerInterface.getVisibleRecentsView<RecentsView<*, *>>()).thenReturn(null)
+            whenever(containerInterface.switchToRecentsIfVisible(any())).thenReturn(false)
+            val (swipeUpHandler, _) = setupGestureDependencies()
+            val command = sut.addCommand(CommandType.SHOW_WITH_FOCUS)!!
+
+            runCurrent()
+            assertThat(command.status).isEqualTo(CommandStatus.PROCESSING)
+            val firstCallbackCaptor = argumentCaptor<Runnable>()
+            verify(swipeUpHandler)
+                .setGestureAnimationEndCallback(firstCallbackCaptor.capture())
+
+            // Launcher was destroyed before Shell finished recents. The command should retry once
+            // after the stale animation is force finished.
+            whenever(swipeUpHandler.gestureAnimationEndResult)
+                .thenReturn(GestureAnimationEndResult.LAUNCHER_DESTROYED)
+            firstCallbackCaptor.firstValue.run()
+            runCurrent()
+
+            assertThat(command.status).isEqualTo(CommandStatus.PROCESSING)
+            verify(swipeUpHandler, times(2)).onGestureStarted(any())
+            val retryCallbackCaptor = argumentCaptor<Runnable>()
+            verify(swipeUpHandler, times(2))
+                .setGestureAnimationEndCallback(retryCallbackCaptor.capture())
+
+            whenever(containerInterface.getVisibleRecentsView<RecentsView<*, *>>())
+                .thenReturn(recentView)
+            whenever(swipeUpHandler.gestureAnimationEndResult)
+                .thenReturn(GestureAnimationEndResult.NORMAL)
+            retryCallbackCaptor.allValues.last().run()
+            runCurrent()
+
+            assertThat(command.status).isEqualTo(CommandStatus.COMPLETED)
+            verify(taskAnimationManager, times(2)).startRecentsAnimation(any(), any(), any())
+        }
+
+    @Test
+    fun showWithFocusCommand_cancelsAfterLauncherDestroyedDuringRetry() =
+        testScope.runTest {
+            whenever(containerInterface.getVisibleRecentsView<RecentsView<*, *>>()).thenReturn(null)
+            whenever(containerInterface.switchToRecentsIfVisible(any())).thenReturn(false)
+            val (swipeUpHandler, _) = setupGestureDependencies()
+            val command = sut.addCommand(CommandType.SHOW_WITH_FOCUS)!!
+
+            runCurrent()
+            val firstCallbackCaptor = argumentCaptor<Runnable>()
+            verify(swipeUpHandler)
+                .setGestureAnimationEndCallback(firstCallbackCaptor.capture())
+
+            whenever(swipeUpHandler.gestureAnimationEndResult)
+                .thenReturn(GestureAnimationEndResult.LAUNCHER_DESTROYED)
+            firstCallbackCaptor.firstValue.run()
+            runCurrent()
+            val retryCallbackCaptor = argumentCaptor<Runnable>()
+            verify(swipeUpHandler, times(2))
+                .setGestureAnimationEndCallback(retryCallbackCaptor.capture())
+
+            // If Launcher is destroyed again during the retry, the user action cannot be preserved.
+            whenever(swipeUpHandler.gestureAnimationEndResult)
+                .thenReturn(GestureAnimationEndResult.LAUNCHER_DESTROYED)
+            retryCallbackCaptor.allValues.last().run()
+            runCurrent()
+
+            assertThat(command.status).isEqualTo(CommandStatus.CANCELED)
+            verify(taskAnimationManager, times(2)).startRecentsAnimation(any(), any(), any())
         }
 
     private fun setupGestureDependencies(): Pair<AbsSwipeUpHandler<*, *, *>, GestureState> {

--- a/quickstep/tests/multivalentTests/src/com/android/quickstep/TaskAnimationManagerTest.java
+++ b/quickstep/tests/multivalentTests/src/com/android/quickstep/TaskAnimationManagerTest.java
@@ -65,6 +65,7 @@ import androidx.test.filters.SmallTest;
 import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.android.app.displaylib.fakes.FakePerDisplayRepository;
+import com.android.internal.os.IResultReceiver;
 import com.android.launcher3.uioverrides.QuickstepLauncher;
 import com.android.launcher3.util.DisplayController;
 import com.android.launcher3.util.Executors;
@@ -329,12 +330,16 @@ public class TaskAnimationManagerTest {
     }
 
     @Test
-    public void testLauncherDestroyed_whileRecentsAnimationStartPending_finishesAnimation() {
+    public void launcherDestroyedBeforeRecentsAnimationStarts_finishesAnimation()
+            throws Exception {
         final GestureState gestureState = buildMockGestureState();
         final ArgumentCaptor<RecentsAnimationCallbacks> listenerCaptor =
                 ArgumentCaptor.forClass(RecentsAnimationCallbacks.class);
+        final ArgumentCaptor<IResultReceiver> finishCallbackCaptor =
+                ArgumentCaptor.forClass(IResultReceiver.class);
         final RecentsAnimationControllerCompat controllerCompat =
                 mock(RecentsAnimationControllerCompat.class);
+        final Runnable forceFinishCompleteCallback = mock(Runnable.class);
         final RemoteAnimationTarget remoteAnimationTarget = new RemoteAnimationTarget(
                 /* taskId= */ 0,
                 /* mode= */ RemoteAnimationTarget.MODE_CLOSING,
@@ -364,8 +369,9 @@ public class TaskAnimationManagerTest {
                     new Intent(),
                     mock(RecentsAnimationCallbacks.RecentsAnimationListener.class));
 
-            // Simulate multiple launcher destroyed events before the recents animation start
-            mTaskAnimationManager.onLauncherDestroyed();
+            // Launcher can be destroyed before Shell calls onAnimationStart. Repeated destroy
+            // events must still result in one force finish and one completion callback.
+            mTaskAnimationManager.onLauncherDestroyed(forceFinishCompleteCallback);
             mTaskAnimationManager.onLauncherDestroyed();
             mTaskAnimationManager.onLauncherDestroyed();
             listenerCaptor.getValue().onAnimationStart(
@@ -377,9 +383,48 @@ public class TaskAnimationManagerTest {
                     new TransitionInfo(0, 0));
         });
 
-        // Verify checks that finish was only called once
+        // The repeated destroy events above should be coalesced into a single controller finish.
         runOnMainSync(() -> verify(controllerCompat)
-                .finish(/* toHome= */ eq(false), anyBoolean(), any()));
+                .finish(/* toHome= */ eq(false), anyBoolean(), finishCallbackCaptor.capture()));
+        verify(forceFinishCompleteCallback, never()).run();
+
+        finishCallbackCaptor.getValue().send(/* resultCode= */ 0, /* resultData= */ null);
+        runOnMainSync(() -> {});
+
+        verify(forceFinishCompleteCallback, times(1)).run();
+    }
+
+    @Test
+    public void launcherDestroyedAfterRecentsAnimationStarts_finishesAnimation()
+            throws Exception {
+        final GestureState gestureState = buildMockGestureState();
+        final RecentsAnimationCallbacks callbacks =
+                startRecentsAnimationAndCaptureCallbacks(gestureState);
+        final RecentsAnimationControllerCompat controllerCompat =
+                mock(RecentsAnimationControllerCompat.class);
+        final ArgumentCaptor<IResultReceiver> finishCallbackCaptor =
+                ArgumentCaptor.forClass(IResultReceiver.class);
+        final Runnable forceFinishCompleteCallback = mock(Runnable.class);
+        final RemoteAnimationTarget appTarget = createRemoteAnimationTarget(
+                /* taskId= */ 0,
+                MODE_CLOSING,
+                ACTIVITY_TYPE_STANDARD,
+                "app.example");
+
+        dispatchRecentsAnimationStart(callbacks, controllerCompat, appTarget);
+
+        // Once Shell has returned a controller, launcher destruction should wait for the
+        // controller finish callback before reporting command completion.
+        runOnMainSync(() -> mTaskAnimationManager.onLauncherDestroyed(forceFinishCompleteCallback));
+
+        runOnMainSync(() -> verify(controllerCompat)
+                .finish(/* toHome= */ eq(false), anyBoolean(), finishCallbackCaptor.capture()));
+        verify(forceFinishCompleteCallback, never()).run();
+
+        finishCallbackCaptor.getValue().send(/* resultCode= */ 0, /* resultData= */ null);
+        runOnMainSync(() -> {});
+
+        verify(forceFinishCompleteCallback, times(1)).run();
     }
 
     @Test
@@ -440,8 +485,16 @@ public class TaskAnimationManagerTest {
 
     private void dispatchRecentsAnimationStart(
             RecentsAnimationCallbacks callbacks, RemoteAnimationTarget... appTargets) {
+        dispatchRecentsAnimationStart(callbacks, mock(RecentsAnimationControllerCompat.class),
+                appTargets);
+    }
+
+    private void dispatchRecentsAnimationStart(
+            RecentsAnimationCallbacks callbacks,
+            RecentsAnimationControllerCompat controller,
+            RemoteAnimationTarget... appTargets) {
         runOnMainSync(() -> callbacks.onAnimationStart(
-                mock(RecentsAnimationControllerCompat.class),
+                controller,
                 appTargets,
                 new RemoteAnimationTarget[0],
                 new Rect(),

--- a/quickstep/tests/multivalentTests/src/com/android/quickstep/TaskAnimationManagerTest.java
+++ b/quickstep/tests/multivalentTests/src/com/android/quickstep/TaskAnimationManagerTest.java
@@ -244,8 +244,10 @@ public class TaskAnimationManagerTest {
     }
 
     @Test
-    public void testRecentsAnimationStartTimeout_cleansUpRecentsAnimation() {
+    public void recentsAnimationStartTimeout_notifiesListenersAndCleansUpAnimation() {
         final GestureState gestureState = buildMockGestureState();
+        final RecentsAnimationCallbacks.RecentsAnimationListener listener =
+                mock(RecentsAnimationCallbacks.RecentsAnimationListener.class);
         when(mSystemUiProxy
                 .startRecentsTransition(any(), any(), any(), anyBoolean(), any(), anyInt()))
                 .thenReturn(true);
@@ -257,16 +259,19 @@ public class TaskAnimationManagerTest {
             mTaskAnimationManager.startRecentsAnimation(
                     gestureState,
                     new Intent(),
-                    mock(RecentsAnimationCallbacks.RecentsAnimationListener.class));
+                    listener);
 
             assertNotNull("TaskAnimationManager was cleaned up prematurely:",
                     mTaskAnimationManager.getCurrentCallbacks());
         });
 
         SystemClock.sleep(RECENTS_ANIMATION_START_TIMEOUT_MS);
+        // The timeout callback posts listener dispatch back to MAIN_EXECUTOR.
+        runOnMainSync(() -> { });
 
         runOnMainSync(() -> assertNull("TaskAnimationManager was not cleaned up after the timeout:",
                 mTaskAnimationManager.getCurrentCallbacks()));
+        verify(listener).onRecentsAnimationStartTimedOut();
     }
 
     protected static void runOnMainSync(Runnable runnable) {

--- a/quickstep/tests/multivalentTests/src/com/android/quickstep/TaskAnimationManagerTest.java
+++ b/quickstep/tests/multivalentTests/src/com/android/quickstep/TaskAnimationManagerTest.java
@@ -16,13 +16,21 @@
 
 package com.android.quickstep;
 
+import static android.app.ActivityTaskManager.INVALID_TASK_ID;
+import static android.app.WindowConfiguration.ACTIVITY_TYPE_HOME;
+import static android.app.WindowConfiguration.ACTIVITY_TYPE_RECENTS;
+import static android.app.WindowConfiguration.ACTIVITY_TYPE_STANDARD;
 import static android.view.Display.DEFAULT_DISPLAY;
+import static android.view.RemoteAnimationTarget.MODE_CLOSING;
+import static android.view.RemoteAnimationTarget.MODE_OPENING;
 
+import static com.android.launcher3.statehandlers.DesktopVisibilityController.INACTIVE_DESK_ID;
 import static com.android.quickstep.TaskAnimationManager.RECENTS_ANIMATION_START_TIMEOUT_MS;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -38,12 +46,16 @@ import static org.mockito.kotlin.OngoingStubbingKt.whenever;
 
 import android.app.ActivityManager;
 import android.app.ActivityOptions;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.graphics.Rect;
 import android.os.Bundle;
 import android.os.SystemClock;
+import android.platform.test.annotations.DisableFlags;
+import android.platform.test.annotations.EnableFlags;
+import android.platform.test.flag.junit.SetFlagsRule;
 import android.view.RemoteAnimationTarget;
 import android.view.SurfaceControl;
 import android.window.TransitionInfo;
@@ -58,6 +70,7 @@ import com.android.launcher3.util.DisplayController;
 import com.android.launcher3.util.Executors;
 import com.android.quickstep.views.RecentsView;
 import com.android.systemui.shared.system.RecentsAnimationControllerCompat;
+import com.android.wm.shell.Flags;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -68,17 +81,26 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 @SmallTest
 @RunWith(AndroidJUnit4.class)
 public class TaskAnimationManagerTest {
     private static final int EXTERNAL_DISPLAY_ID = 1;
+    private static final int ROOT_HOME_TASK_ID = 1;
+    private static final int LEGACY_HOME_TASK_ID = 1161;
+    private static final int RECENTS_TASK_ID = 1162;
+    private static final String THIRD_PARTY_HOME_PACKAGE = "app.lawnchair";
+
     protected final Context mContext =
             InstrumentationRegistry.getInstrumentation().getTargetContext();
 
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Rule
+    public final SetFlagsRule mSetFlagsRule = new SetFlagsRule();
 
     @Mock
     private SystemUiProxy mSystemUiProxy;
@@ -190,6 +212,123 @@ public class TaskAnimationManagerTest {
     }
 
     @Test
+    @DisableFlags(Flags.FLAG_ENABLE_SHELL_TOP_TASK_TRACKING)
+    public void thirdPartyHomeTaskIdMismatch_usesMatchingHomeAnimationTarget() {
+        // Legacy tracking reports the third-party home child task while Shell animates the root
+        // home task for the same launcher.
+        // Repro log shape:
+        // runningTaskIds=[1161] appTargets=[{taskId=1, activityType=2, ...}]
+        // RemoteAnimationTargets: taskId: 1161 not found. apps contains: [1]
+        GestureState gestureState = buildMockGestureState(
+                buildCachedTaskInfo(LEGACY_HOME_TASK_ID, ACTIVITY_TYPE_HOME,
+                        THIRD_PARTY_HOME_PACKAGE),
+                new int[] {LEGACY_HOME_TASK_ID});
+        RecentsAnimationCallbacks callbacks =
+                startRecentsAnimationAndCaptureCallbacks(gestureState);
+        RemoteAnimationTarget recentsTarget = createRemoteAnimationTarget(
+                RECENTS_TASK_ID, MODE_OPENING, ACTIVITY_TYPE_RECENTS,
+                "com.android.launcher3");
+        RemoteAnimationTarget rootHomeTarget = createRemoteAnimationTarget(
+                ROOT_HOME_TASK_ID, MODE_CLOSING, ACTIVITY_TYPE_HOME,
+                THIRD_PARTY_HOME_PACKAGE);
+
+        dispatchRecentsAnimationStartAndAssertLastAppearedTask(
+                gestureState, callbacks, LEGACY_HOME_TASK_ID, rootHomeTarget,
+                recentsTarget, rootHomeTarget);
+    }
+
+    @Test
+    @DisableFlags(Flags.FLAG_ENABLE_SHELL_TOP_TASK_TRACKING)
+    public void continuedRecentsAnimation_keepsThirdPartyHomeTaskIdForLookup() {
+        GestureState gestureState = buildMockGestureState(
+                buildCachedTaskInfo(LEGACY_HOME_TASK_ID, ACTIVITY_TYPE_HOME,
+                        THIRD_PARTY_HOME_PACKAGE),
+                new int[] {LEGACY_HOME_TASK_ID});
+        RecentsAnimationCallbacks callbacks =
+                startRecentsAnimationAndCaptureCallbacks(gestureState);
+        RemoteAnimationTarget recentsTarget = createRemoteAnimationTarget(
+                RECENTS_TASK_ID, MODE_OPENING, ACTIVITY_TYPE_RECENTS,
+                "com.android.launcher3");
+        RemoteAnimationTarget rootHomeTarget = createRemoteAnimationTarget(
+                ROOT_HOME_TASK_ID, MODE_CLOSING, ACTIVITY_TYPE_HOME,
+                THIRD_PARTY_HOME_PACKAGE);
+        dispatchRecentsAnimationStart(callbacks, recentsTarget, rootHomeTarget);
+
+        GestureState continuedGestureState = buildMockGestureState();
+        runOnMainSync(() -> mTaskAnimationManager.continueRecentsAnimation(continuedGestureState));
+
+        LastAppearedTasks lastAppearedTasks = captureLastAppearedTasks(continuedGestureState);
+        assertEquals(1, lastAppearedTasks.targets.length);
+        assertSame(rootHomeTarget, lastAppearedTasks.targets[0]);
+        assertEquals(1, lastAppearedTasks.taskIds.length);
+        assertEquals(LEGACY_HOME_TASK_ID, lastAppearedTasks.taskIds[0]);
+    }
+
+    @Test
+    @DisableFlags(Flags.FLAG_ENABLE_SHELL_TOP_TASK_TRACKING)
+    public void nonHomeTaskIdMismatch_doesNotUseHomeTargetFallback() {
+        GestureState gestureState = buildMockGestureState(
+                buildCachedTaskInfo(LEGACY_HOME_TASK_ID, ACTIVITY_TYPE_STANDARD,
+                        "app.example"),
+                new int[] {LEGACY_HOME_TASK_ID});
+        RecentsAnimationCallbacks callbacks =
+                startRecentsAnimationAndCaptureCallbacks(gestureState);
+        RemoteAnimationTarget recentsTarget = createRemoteAnimationTarget(
+                RECENTS_TASK_ID, MODE_OPENING, ACTIVITY_TYPE_RECENTS,
+                "com.android.launcher3");
+        RemoteAnimationTarget appTarget = createRemoteAnimationTarget(
+                ROOT_HOME_TASK_ID, MODE_CLOSING, ACTIVITY_TYPE_STANDARD,
+                "app.example");
+
+        dispatchRecentsAnimationStartAndAssertNoLastAppearedTarget(
+                gestureState, callbacks, recentsTarget, appTarget);
+    }
+
+    @Test
+    @DisableFlags(Flags.FLAG_ENABLE_SHELL_TOP_TASK_TRACKING)
+    public void multipleMatchingHomeTargets_doesNotGuessFallbackTarget() {
+        GestureState gestureState = buildMockGestureState(
+                buildCachedTaskInfo(LEGACY_HOME_TASK_ID, ACTIVITY_TYPE_HOME,
+                        THIRD_PARTY_HOME_PACKAGE),
+                new int[] {LEGACY_HOME_TASK_ID});
+        RecentsAnimationCallbacks callbacks =
+                startRecentsAnimationAndCaptureCallbacks(gestureState);
+        RemoteAnimationTarget recentsTarget = createRemoteAnimationTarget(
+                RECENTS_TASK_ID, MODE_OPENING, ACTIVITY_TYPE_RECENTS,
+                "com.android.launcher3");
+        RemoteAnimationTarget firstHomeTarget = createRemoteAnimationTarget(
+                ROOT_HOME_TASK_ID, MODE_CLOSING, ACTIVITY_TYPE_HOME,
+                THIRD_PARTY_HOME_PACKAGE);
+        RemoteAnimationTarget secondHomeTarget = createRemoteAnimationTarget(
+                ROOT_HOME_TASK_ID + 1, MODE_CLOSING, ACTIVITY_TYPE_HOME,
+                THIRD_PARTY_HOME_PACKAGE);
+
+        dispatchRecentsAnimationStartAndAssertNoLastAppearedTarget(
+                gestureState, callbacks, recentsTarget, firstHomeTarget, secondHomeTarget);
+    }
+
+    @Test
+    @EnableFlags(Flags.FLAG_ENABLE_SHELL_TOP_TASK_TRACKING)
+    public void shellTopTaskTracking_usesExactHomeAnimationTarget() {
+        GestureState gestureState = buildMockGestureState(
+                buildCachedTaskInfo(ROOT_HOME_TASK_ID, ACTIVITY_TYPE_HOME,
+                        THIRD_PARTY_HOME_PACKAGE),
+                new int[] {ROOT_HOME_TASK_ID});
+        RecentsAnimationCallbacks callbacks =
+                startRecentsAnimationAndCaptureCallbacks(gestureState);
+        RemoteAnimationTarget recentsTarget = createRemoteAnimationTarget(
+                RECENTS_TASK_ID, MODE_OPENING, ACTIVITY_TYPE_RECENTS,
+                "com.android.launcher3");
+        RemoteAnimationTarget rootHomeTarget = createRemoteAnimationTarget(
+                ROOT_HOME_TASK_ID, MODE_CLOSING, ACTIVITY_TYPE_HOME,
+                THIRD_PARTY_HOME_PACKAGE);
+
+        dispatchRecentsAnimationStartAndAssertLastAppearedTask(
+                gestureState, callbacks, ROOT_HOME_TASK_ID, rootHomeTarget,
+                recentsTarget, rootHomeTarget);
+    }
+
+    @Test
     public void testLauncherDestroyed_whileRecentsAnimationStartPending_finishesAnimation() {
         final GestureState gestureState = buildMockGestureState();
         final ArgumentCaptor<RecentsAnimationCallbacks> listenerCaptor =
@@ -283,6 +422,80 @@ public class TaskAnimationManagerTest {
         }
     }
 
+    private RecentsAnimationCallbacks startRecentsAnimationAndCaptureCallbacks(
+            GestureState gestureState) {
+        final ArgumentCaptor<RecentsAnimationCallbacks> callbacksCaptor =
+                ArgumentCaptor.forClass(RecentsAnimationCallbacks.class);
+        when(mSystemUiProxy.startRecentsTransition(
+                any(), any(), callbacksCaptor.capture(), anyBoolean(), any(), anyInt()))
+                .thenReturn(false);
+
+        runOnMainSync(() -> mTaskAnimationManager.startRecentsAnimation(
+                gestureState,
+                new Intent(),
+                mock(RecentsAnimationCallbacks.RecentsAnimationListener.class)));
+
+        return callbacksCaptor.getValue();
+    }
+
+    private void dispatchRecentsAnimationStart(
+            RecentsAnimationCallbacks callbacks, RemoteAnimationTarget... appTargets) {
+        runOnMainSync(() -> callbacks.onAnimationStart(
+                mock(RecentsAnimationControllerCompat.class),
+                appTargets,
+                new RemoteAnimationTarget[0],
+                new Rect(),
+                new Bundle(),
+                new TransitionInfo(0, 0)));
+    }
+
+    private void dispatchRecentsAnimationStartAndAssertLastAppearedTask(
+            GestureState gestureState,
+            RecentsAnimationCallbacks callbacks,
+            int expectedTaskIdForLookup,
+            RemoteAnimationTarget expectedTarget,
+            RemoteAnimationTarget... appTargets) {
+        dispatchRecentsAnimationStart(callbacks, appTargets);
+
+        LastAppearedTasks lastAppearedTasks = captureLastAppearedTasks(gestureState);
+        assertEquals(1, lastAppearedTasks.targets.length);
+        assertSame(expectedTarget, lastAppearedTasks.targets[0]);
+        assertEquals(1, lastAppearedTasks.taskIds.length);
+        assertEquals(expectedTaskIdForLookup, lastAppearedTasks.taskIds[0]);
+    }
+
+    private void dispatchRecentsAnimationStartAndAssertNoLastAppearedTarget(
+            GestureState gestureState,
+            RecentsAnimationCallbacks callbacks,
+            RemoteAnimationTarget... appTargets) {
+        dispatchRecentsAnimationStart(callbacks, appTargets);
+
+        LastAppearedTasks lastAppearedTasks = captureLastAppearedTasks(gestureState);
+        assertEquals(1, lastAppearedTasks.targets.length);
+        assertNull(lastAppearedTasks.targets[0]);
+        assertEquals(1, lastAppearedTasks.taskIds.length);
+        assertEquals(INVALID_TASK_ID, lastAppearedTasks.taskIds[0]);
+    }
+
+    private LastAppearedTasks captureLastAppearedTasks(GestureState gestureState) {
+        ArgumentCaptor<RemoteAnimationTarget[]> targetCaptor =
+                ArgumentCaptor.forClass(RemoteAnimationTarget[].class);
+        ArgumentCaptor<int[]> taskIdCaptor = ArgumentCaptor.forClass(int[].class);
+        verify(gestureState).updateLastAppearedTaskTargets(targetCaptor.capture(),
+                taskIdCaptor.capture());
+        return new LastAppearedTasks(targetCaptor.getValue(), taskIdCaptor.getValue());
+    }
+
+    private static final class LastAppearedTasks {
+        final RemoteAnimationTarget[] targets;
+        final int[] taskIds;
+
+        LastAppearedTasks(RemoteAnimationTarget[] targets, int[] taskIds) {
+            this.targets = targets;
+            this.taskIds = taskIds;
+        }
+    }
+
     private GestureState buildMockGestureState() {
         final GestureState gestureState = mock(GestureState.class);
 
@@ -290,5 +503,60 @@ public class TaskAnimationManagerTest {
         when(gestureState.getRunningTaskIds(anyBoolean())).thenReturn(new int[0]);
 
         return gestureState;
+    }
+
+    private GestureState buildMockGestureState(
+            TopTaskTracker.CachedTaskInfo runningTask, int[] runningTaskIds) {
+        GestureState gestureState = buildMockGestureState();
+        when(gestureState.getRunningTask()).thenReturn(runningTask);
+        when(gestureState.getRunningTaskIds(anyBoolean())).thenReturn(runningTaskIds);
+        return gestureState;
+    }
+
+    private TopTaskTracker.CachedTaskInfo buildCachedTaskInfo(
+            int taskId, int activityType, String packageName) {
+        return new TopTaskTracker.CachedTaskInfo(
+                List.of(createTaskInfo(taskId, activityType, packageName)),
+                mContext,
+                DEFAULT_DISPLAY,
+                INACTIVE_DESK_ID);
+    }
+
+    private RemoteAnimationTarget createRemoteAnimationTarget(
+            int taskId, int mode, int activityType, String packageName) {
+        ActivityManager.RunningTaskInfo taskInfo =
+                createTaskInfo(taskId, activityType, packageName);
+        return new RemoteAnimationTarget(
+                taskId,
+                mode,
+                new SurfaceControl(),
+                false,
+                new Rect(),
+                new Rect(),
+                0,
+                null,
+                new Rect(),
+                new Rect(),
+                taskInfo.configuration.windowConfiguration,
+                false,
+                null,
+                null,
+                taskInfo,
+                false);
+    }
+
+    private ActivityManager.RunningTaskInfo createTaskInfo(
+            int taskId, int activityType, String packageName) {
+        ComponentName componentName = new ComponentName(packageName, packageName + ".Activity");
+        ActivityManager.RunningTaskInfo taskInfo = new ActivityManager.RunningTaskInfo();
+        taskInfo.taskId = taskId;
+        taskInfo.userId = 0;
+        taskInfo.displayId = DEFAULT_DISPLAY;
+        taskInfo.baseIntent = new Intent().setComponent(componentName);
+        taskInfo.baseActivity = componentName;
+        taskInfo.topActivity = componentName;
+        taskInfo.realActivity = componentName;
+        taskInfo.configuration.windowConfiguration.setActivityType(activityType);
+        return taskInfo;
     }
 }


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/7813

Fixes issues with recents button being unresponsive with 3rd party launchers and 3-button navigation due to com.android.quickstep.RecentsActivity being recreated 

Bug appearance (can also be reproduced by just toggling dark theme in OS Settings then attempting to press recents)

https://github.com/user-attachments/assets/84715d3a-61b8-414a-abcc-ddc8ced00418